### PR TITLE
chore: upgrade pnpm to v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"typescript": "^5.7.2",
 		"vitest": "^2.1.8"
 	},
-	"packageManager": "pnpm@9.15.1",
+	"packageManager": "pnpm@10.26.2",
 	"engines": {
 		"node": ">=22"
 	}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,7 +31,7 @@
 	},
 	"devDependencies": {
 		"@types/prompts": "^2.4.9",
-		"tsdown": "^0.18.0"
+		"tsdown": "catalog:"
 	},
 	"keywords": [
 		"screenbook",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,7 +26,7 @@
 		"zod": "^4.0.0"
 	},
 	"devDependencies": {
-		"tsdown": "^0.18.0"
+		"tsdown": "catalog:"
 	},
 	"keywords": [
 		"screenbook",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    tsdown:
+      specifier: ^0.18.0
+      version: 0.18.3
+
 importers:
 
   .:
@@ -61,7 +67,7 @@ importers:
         specifier: ^2.4.9
         version: 2.4.9
       tsdown:
-        specifier: ^0.18.0
+        specifier: 'catalog:'
         version: 0.18.3(typescript@5.9.3)
 
   packages/core:
@@ -71,7 +77,7 @@ importers:
         version: 4.2.1
     devDependencies:
       tsdown:
-        specifier: ^0.18.0
+        specifier: 'catalog:'
         version: 0.18.3(typescript@5.9.3)
 
   packages/ui:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 packages:
   - "packages/*"
   - "examples/*"
+
+catalog:
+  tsdown: ^0.18.0


### PR DESCRIPTION
## Summary
- Upgrade pnpm from v9.15.1 to v10.26.2
- Add pnpm catalog support for shared dependencies (`tsdown`)
- Regenerate lockfile with pnpm v10 format

## Breaking Changes (pnpm v10)
- Lifecycle scripts disabled by default (no impact on this project)
- Store structure updated to v10

## Test plan
- [x] All packages build successfully
- [x] All tests pass
- [x] Lint and typecheck pass

Closes #17