### PR TITLE
chore: add GitHub community health files and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,54 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the form below.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of what the bug is.
+      placeholder: Describe the bug...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Run `screenbook build`
+        2. See error...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Please provide your environment details.
+      value: |
+        - OS:
+        - Node.js version:
+        - Screenbook version:
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Add any other context, screenshots, or error logs.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://wadakatu.github.io/screenbook
+    about: Check the documentation before opening an issue

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,37 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please describe your idea below.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem does this feature solve? Is it related to a frustration?
+      placeholder: I'm always frustrated when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Describe any alternative solutions or features you've considered.
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Add any other context, mockups, or examples.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Summary
+
+<!-- Brief description of what this PR does -->
+
+## Changes
+
+<!-- List the main changes -->
+
+-
+
+## Related Issues
+
+<!-- Link any related issues: Fixes #123, Closes #456 -->
+
+## Checklist
+
+- [ ] Tests pass (`pnpm test`)
+- [ ] Linting passes (`pnpm biome check`)
+- [ ] Documentation updated (if applicable)
+- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,32 @@
+# Code of Conduct
+
+## Our Pledge
+
+We are committed to providing a friendly, safe, and welcoming environment for all contributors, regardless of experience level, gender identity, sexual orientation, disability, personal appearance, race, ethnicity, age, religion, or nationality.
+
+## Our Standards
+
+**Positive behaviors include:**
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards others
+
+**Unacceptable behaviors include:**
+
+- Harassment, trolling, or insulting comments
+- Personal or political attacks
+- Publishing others' private information without permission
+- Any conduct that could reasonably be considered inappropriate
+
+## Enforcement
+
+Project maintainers are responsible for clarifying standards of acceptable behavior and may take appropriate action in response to any unacceptable behavior.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project maintainers.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,118 @@
+# Contributing to Screenbook
+
+Thank you for your interest in contributing to Screenbook! This document provides guidelines and instructions for contributing.
+
+## Development Setup
+
+### Prerequisites
+
+- Node.js 22+
+- pnpm 9+
+
+### Getting Started
+
+```bash
+# Clone the repository
+git clone https://github.com/wadakatu/screenbook.git
+cd screenbook
+
+# Install dependencies
+pnpm install
+
+# Build all packages
+pnpm -r run build
+
+# Run tests
+pnpm test
+```
+
+## Project Structure
+
+```
+screenbook/
+├── packages/
+│   ├── core/     # @screenbook/core - Type definitions and utilities
+│   ├── cli/      # @screenbook/cli - Command-line interface
+│   └── ui/       # @screenbook/ui - Astro-based UI
+├── docs/         # Documentation site
+└── .github/      # GitHub workflows and templates
+```
+
+## Development Workflow
+
+### Code Style
+
+We use [Biome](https://biomejs.dev/) for linting and formatting:
+
+```bash
+# Check for issues
+pnpm biome check
+
+# Auto-fix issues
+pnpm biome check --write
+```
+
+### Testing
+
+We use [Vitest](https://vitest.dev/) for testing:
+
+```bash
+# Run all tests
+pnpm test
+
+# Run tests for a specific package
+pnpm -r --filter @screenbook/cli run test
+```
+
+### Commit Messages
+
+We follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+- `feat:` - New features
+- `fix:` - Bug fixes
+- `docs:` - Documentation changes
+- `refactor:` - Code refactoring
+- `test:` - Test additions or changes
+- `chore:` - Build process or tooling changes
+
+Examples:
+```
+feat(cli): add --strict flag to lint command
+fix(core): handle undefined screen IDs
+docs: update README with new examples
+```
+
+## Pull Request Process
+
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feat/amazing-feature`)
+3. Make your changes
+4. Run tests and linting (`pnpm test && pnpm biome check`)
+5. Commit with a descriptive message
+6. Push to your fork
+7. Open a Pull Request
+
+### PR Guidelines
+
+- Keep PRs focused on a single change
+- Update documentation if needed
+- Add tests for new features
+- Ensure CI passes before requesting review
+
+## Reporting Issues
+
+When reporting bugs, please include:
+
+- Screenbook version
+- Node.js version
+- Operating system
+- Steps to reproduce
+- Expected vs actual behavior
+
+## Questions?
+
+Feel free to open an issue for any questions or discussions.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the MIT License.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/wadakatu/screenbook/actions/workflows/ci.yml"><img src="https://github.com/wadakatu/screenbook/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://github.com/wadakatu/screenbook/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>
   <a href="https://github.com/wadakatu/screenbook"><img src="https://img.shields.io/badge/TypeScript-5.0+-blue.svg" alt="TypeScript"></a>
   <a href="https://github.com/wadakatu/screenbook"><img src="https://img.shields.io/badge/Node.js-22+-green.svg" alt="Node.js"></a>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Screenbook, please report it responsibly:
+
+1. **Do not** open a public issue
+2. Email the maintainers or use GitHub's private vulnerability reporting feature
+3. Include details about the vulnerability and steps to reproduce
+
+We will respond as quickly as possible and work with you to understand and address the issue.
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| latest  | :white_check_mark: |
+
+## Security Best Practices
+
+When using Screenbook:
+
+- Keep your dependencies up to date
+- Review screen metadata before committing (avoid exposing sensitive route information)
+- Use the latest version of Node.js with security patches
+
+## Acknowledgments
+
+We appreciate responsible disclosure of security issues.


### PR DESCRIPTION
## Summary

Add GitHub community health files and templates to improve the repository's developer experience.

## Changes

- Add issue templates (bug report, feature request) with YAML format
- Add pull request template
- Add CONTRIBUTING.md with development setup and guidelines
- Add CODE_OF_CONDUCT.md (Contributor Covenant)
- Add SECURITY.md with vulnerability reporting policy
- Add CI badge to README

## Related

Also configured via gh CLI (already applied):
- Added repository topics
- Set homepage URL to docs site

## Checklist

- [x] Tests pass (`pnpm test`)
- [x] Linting passes (`pnpm biome check`)
- [x] Documentation updated (if applicable)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)