### PR TITLE
fix(ci): use OIDC for npm publish instead of token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,6 @@ jobs:
         with:
           node-version: "22"
           cache: "pnpm"
-          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -73,13 +72,13 @@ jobs:
         run: pnpm build
 
       - name: Publish @screenbook/core
-        run: npm publish --access public
+        run: npm publish --access public --provenance
         working-directory: packages/core
 
       - name: Publish @screenbook/cli
-        run: npm publish --access public
+        run: npm publish --access public --provenance
         working-directory: packages/cli
 
       - name: Publish @screenbook/ui
-        run: npm publish --access public
+        run: npm publish --access public --provenance
         working-directory: packages/ui


### PR DESCRIPTION
## Summary

Fix npm OIDC publishing by removing token-based authentication setup.

## Changes

- Remove `registry-url` from `actions/setup-node` (it creates an .npmrc expecting a token, which conflicts with OIDC)
- Add `--provenance` flag to publish commands for OIDC attestation
- npm CLI auto-detects OIDC environment when `id-token: write` permission is set

## Related

Fixes Release workflow failures caused by OIDC authentication issues.

## Checklist

- [x] Tests pass (`pnpm test`)
- [x] Linting passes (`pnpm biome check`)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)