### PR TITLE
fix(ci): upgrade npm to latest for OIDC support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Build packages
         run: pnpm build
 
+      - name: Upgrade npm for OIDC support
+        run: npm install -g npm@latest
+
       - name: Publish @screenbook/core
         run: npm publish --access public --provenance
         working-directory: packages/core


### PR DESCRIPTION
## Summary

Fix npm OIDC publishing by upgrading npm CLI to the latest version.

## Changes

- Add `npm install -g npm@latest` step before publishing
- npm OIDC trusted publishing requires npm >=11.5.1
- Node.js 22's bundled npm version is older than required

## Reference

- [npm trusted publishing docs](https://docs.npmjs.com/trusted-publishers/)
- [Setup guide](https://remarkablemark.org/blog/2025/12/19/npm-trusted-publishing/)

## Checklist

- [x] Tests pass (`pnpm test`)
- [x] Linting passes (`pnpm biome check`)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)