### PR TITLE
chore: release v1.0.0

### DIFF
--- a/docs/src/content/docs/api/functions/defineConfig.md
+++ b/docs/src/content/docs/api/functions/defineConfig.md
@@ -7,7 +7,7 @@ title: "defineConfig"
 
 > **defineConfig**(`input`): [`Config`](/screenbook/api/interfaces/config/)
 
-Defined in: [packages/core/src/defineScreen.ts:43](https://github.com/wadakatu/screenbook/blob/b46f17911c7424f697e59b3c5c1e4a9e75b6b7c3/packages/core/src/defineScreen.ts#L43)
+Defined in: [packages/core/src/defineScreen.ts:43](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/defineScreen.ts#L43)
 
 Define Screenbook configuration.
 

--- a/docs/src/content/docs/api/functions/defineScreen.md
+++ b/docs/src/content/docs/api/functions/defineScreen.md
@@ -7,7 +7,7 @@ title: "defineScreen"
 
 > **defineScreen**(`input`): [`Screen`](/screenbook/api/interfaces/screen/)
 
-Defined in: [packages/core/src/defineScreen.ts:27](https://github.com/wadakatu/screenbook/blob/b46f17911c7424f697e59b3c5c1e4a9e75b6b7c3/packages/core/src/defineScreen.ts#L27)
+Defined in: [packages/core/src/defineScreen.ts:27](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/defineScreen.ts#L27)
 
 Define a screen with metadata for the screen catalog.
 

--- a/docs/src/content/docs/api/interfaces/AdoptionConfig.md
+++ b/docs/src/content/docs/api/interfaces/AdoptionConfig.md
@@ -5,7 +5,7 @@ prev: false
 title: "AdoptionConfig"
 ---
 
-Defined in: [packages/core/src/types.ts:161](https://github.com/wadakatu/screenbook/blob/b46f17911c7424f697e59b3c5c1e4a9e75b6b7c3/packages/core/src/types.ts#L161)
+Defined in: [packages/core/src/types.ts:161](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L161)
 
 Progressive adoption configuration for gradual rollout.
 
@@ -25,7 +25,7 @@ const adoption: AdoptionConfig = {
 
 > `optional` **includePatterns**: `string`[]
 
-Defined in: [packages/core/src/types.ts:177](https://github.com/wadakatu/screenbook/blob/b46f17911c7424f697e59b3c5c1e4a9e75b6b7c3/packages/core/src/types.ts#L177)
+Defined in: [packages/core/src/types.ts:177](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L177)
 
 Glob patterns to include for coverage checking (progressive mode only)
 
@@ -45,7 +45,7 @@ Glob patterns to include for coverage checking (progressive mode only)
 
 > `optional` **minimumCoverage**: `number`
 
-Defined in: [packages/core/src/types.ts:184](https://github.com/wadakatu/screenbook/blob/b46f17911c7424f697e59b3c5c1e4a9e75b6b7c3/packages/core/src/types.ts#L184)
+Defined in: [packages/core/src/types.ts:184](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L184)
 
 Minimum coverage percentage required to pass lint (0-100)
 
@@ -65,7 +65,7 @@ Minimum coverage percentage required to pass lint (0-100)
 
 > `optional` **mode**: `"full"` \| `"progressive"`
 
-Defined in: [packages/core/src/types.ts:170](https://github.com/wadakatu/screenbook/blob/b46f17911c7424f697e59b3c5c1e4a9e75b6b7c3/packages/core/src/types.ts#L170)
+Defined in: [packages/core/src/types.ts:170](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L170)
 
 Adoption mode for screen metadata coverage
 - `"full"`: All routes must have screen.meta.ts (default)

--- a/docs/src/content/docs/api/interfaces/Config.md
+++ b/docs/src/content/docs/api/interfaces/Config.md
@@ -5,7 +5,7 @@ prev: false
 title: "Config"
 ---
 
-Defined in: [packages/core/src/types.ts:200](https://github.com/wadakatu/screenbook/blob/b46f17911c7424f697e59b3c5c1e4a9e75b6b7c3/packages/core/src/types.ts#L200)
+Defined in: [packages/core/src/types.ts:200](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L200)
 
 Screenbook configuration options.
 
@@ -15,7 +15,7 @@ Screenbook configuration options.
 
 > `optional` **adoption**: [`AdoptionConfig`](/screenbook/api/interfaces/adoptionconfig/)
 
-Defined in: [packages/core/src/types.ts:236](https://github.com/wadakatu/screenbook/blob/b46f17911c7424f697e59b3c5c1e4a9e75b6b7c3/packages/core/src/types.ts#L236)
+Defined in: [packages/core/src/types.ts:236](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L236)
 
 Progressive adoption configuration for gradual rollout
 
@@ -31,7 +31,7 @@ Progressive adoption configuration for gradual rollout
 
 > **ignore**: `string`[]
 
-Defined in: [packages/core/src/types.ts:230](https://github.com/wadakatu/screenbook/blob/b46f17911c7424f697e59b3c5c1e4a9e75b6b7c3/packages/core/src/types.ts#L230)
+Defined in: [packages/core/src/types.ts:230](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L230)
 
 Patterns to ignore when scanning (glob patterns).
 Defaults to node_modules and .git directories.
@@ -42,7 +42,7 @@ Defaults to node_modules and .git directories.
 
 > **metaPattern**: `string`
 
-Defined in: [packages/core/src/types.ts:216](https://github.com/wadakatu/screenbook/blob/b46f17911c7424f697e59b3c5c1e4a9e75b6b7c3/packages/core/src/types.ts#L216)
+Defined in: [packages/core/src/types.ts:216](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L216)
 
 Glob pattern for screen metadata files.
 Supports colocation: place screen.meta.ts alongside your route files.
@@ -69,7 +69,7 @@ Supports colocation: place screen.meta.ts alongside your route files.
 
 > **outDir**: `string`
 
-Defined in: [packages/core/src/types.ts:207](https://github.com/wadakatu/screenbook/blob/b46f17911c7424f697e59b3c5c1e4a9e75b6b7c3/packages/core/src/types.ts#L207)
+Defined in: [packages/core/src/types.ts:207](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L207)
 
 Output directory for generated files
 
@@ -95,7 +95,7 @@ Output directory for generated files
 
 > `optional` **routesPattern**: `string`
 
-Defined in: [packages/core/src/types.ts:224](https://github.com/wadakatu/screenbook/blob/b46f17911c7424f697e59b3c5c1e4a9e75b6b7c3/packages/core/src/types.ts#L224)
+Defined in: [packages/core/src/types.ts:224](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L224)
 
 Glob pattern for route files (for generate/lint commands)
 

--- a/docs/src/content/docs/api/interfaces/ConfigInput.md
+++ b/docs/src/content/docs/api/interfaces/ConfigInput.md
@@ -5,7 +5,7 @@ prev: false
 title: "ConfigInput"
 ---
 
-Defined in: [packages/core/src/types.ts:251](https://github.com/wadakatu/screenbook/blob/b46f17911c7424f697e59b3c5c1e4a9e75b6b7c3/packages/core/src/types.ts#L251)
+Defined in: [packages/core/src/types.ts:251](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L251)
 
 Input type for defineConfig function.
 All fields with defaults are optional in input.
@@ -25,7 +25,7 @@ defineConfig({
 
 > `optional` **adoption**: [`AdoptionConfig`](/screenbook/api/interfaces/adoptionconfig/)
 
-Defined in: [packages/core/src/types.ts:281](https://github.com/wadakatu/screenbook/blob/b46f17911c7424f697e59b3c5c1e4a9e75b6b7c3/packages/core/src/types.ts#L281)
+Defined in: [packages/core/src/types.ts:281](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L281)
 
 Progressive adoption configuration
 
@@ -35,7 +35,7 @@ Progressive adoption configuration
 
 > `optional` **ignore**: `string`[]
 
-Defined in: [packages/core/src/types.ts:276](https://github.com/wadakatu/screenbook/blob/b46f17911c7424f697e59b3c5c1e4a9e75b6b7c3/packages/core/src/types.ts#L276)
+Defined in: [packages/core/src/types.ts:276](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L276)
 
 Patterns to ignore when scanning.
 Defaults to node_modules and .git directories.
@@ -46,7 +46,7 @@ Defaults to node_modules and .git directories.
 
 > `optional` **metaPattern**: `string`
 
-Defined in: [packages/core/src/types.ts:264](https://github.com/wadakatu/screenbook/blob/b46f17911c7424f697e59b3c5c1e4a9e75b6b7c3/packages/core/src/types.ts#L264)
+Defined in: [packages/core/src/types.ts:264](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L264)
 
 Glob pattern for screen metadata files
 
@@ -68,7 +68,7 @@ Glob pattern for screen metadata files
 
 > `optional` **outDir**: `string`
 
-Defined in: [packages/core/src/types.ts:257](https://github.com/wadakatu/screenbook/blob/b46f17911c7424f697e59b3c5c1e4a9e75b6b7c3/packages/core/src/types.ts#L257)
+Defined in: [packages/core/src/types.ts:257](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L257)
 
 Output directory for generated files
 
@@ -90,7 +90,7 @@ Output directory for generated files
 
 > `optional` **routesPattern**: `string`
 
-Defined in: [packages/core/src/types.ts:270](https://github.com/wadakatu/screenbook/blob/b46f17911c7424f697e59b3c5c1e4a9e75b6b7c3/packages/core/src/types.ts#L270)
+Defined in: [packages/core/src/types.ts:270](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L270)
 
 Glob pattern for route files (for generate/lint commands)
 

--- a/docs/src/content/docs/api/interfaces/Screen.md
+++ b/docs/src/content/docs/api/interfaces/Screen.md
@@ -5,7 +5,7 @@ prev: false
 title: "Screen"
 ---
 
-Defined in: [packages/core/src/types.ts:37](https://github.com/wadakatu/screenbook/blob/b46f17911c7424f697e59b3c5c1e4a9e75b6b7c3/packages/core/src/types.ts#L37)
+Defined in: [packages/core/src/types.ts:37](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L37)
 
 Screen metadata definition for the screen catalog.
 
@@ -29,7 +29,7 @@ const screen: Screen = {
 
 > `optional` **allowCycles**: `boolean`
 
-Defined in: [packages/core/src/types.ts:103](https://github.com/wadakatu/screenbook/blob/b46f17911c7424f697e59b3c5c1e4a9e75b6b7c3/packages/core/src/types.ts#L103)
+Defined in: [packages/core/src/types.ts:103](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L103)
 
 Allow circular navigation involving this screen.
 When true, cycles that include this screen will not trigger warnings.
@@ -52,7 +52,7 @@ true
 
 > `optional` **dependsOn**: `string`[]
 
-Defined in: [packages/core/src/types.ts:81](https://github.com/wadakatu/screenbook/blob/b46f17911c7424f697e59b3c5c1e4a9e75b6b7c3/packages/core/src/types.ts#L81)
+Defined in: [packages/core/src/types.ts:81](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L81)
 
 APIs or services this screen depends on for impact analysis
 
@@ -72,7 +72,7 @@ APIs or services this screen depends on for impact analysis
 
 > `optional` **description**: `string`
 
-Defined in: [packages/core/src/types.ts:109](https://github.com/wadakatu/screenbook/blob/b46f17911c7424f697e59b3c5c1e4a9e75b6b7c3/packages/core/src/types.ts#L109)
+Defined in: [packages/core/src/types.ts:109](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L109)
 
 Optional description explaining the screen's purpose
 
@@ -88,7 +88,7 @@ Optional description explaining the screen's purpose
 
 > `optional` **entryPoints**: `string`[]
 
-Defined in: [packages/core/src/types.ts:88](https://github.com/wadakatu/screenbook/blob/b46f17911c7424f697e59b3c5c1e4a9e75b6b7c3/packages/core/src/types.ts#L88)
+Defined in: [packages/core/src/types.ts:88](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L88)
 
 Screen IDs that can navigate to this screen (incoming edges)
 
@@ -108,7 +108,7 @@ Screen IDs that can navigate to this screen (incoming edges)
 
 > **id**: `string`
 
-Defined in: [packages/core/src/types.ts:44](https://github.com/wadakatu/screenbook/blob/b46f17911c7424f697e59b3c5c1e4a9e75b6b7c3/packages/core/src/types.ts#L44)
+Defined in: [packages/core/src/types.ts:44](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L44)
 
 Unique identifier for the screen using dot notation
 
@@ -132,7 +132,7 @@ Unique identifier for the screen using dot notation
 
 > `optional` **links**: `ScreenLink`[]
 
-Defined in: [packages/core/src/types.ts:115](https://github.com/wadakatu/screenbook/blob/b46f17911c7424f697e59b3c5c1e4a9e75b6b7c3/packages/core/src/types.ts#L115)
+Defined in: [packages/core/src/types.ts:115](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L115)
 
 Links to external resources like Storybook, Figma, or documentation
 
@@ -148,7 +148,7 @@ Links to external resources like Storybook, Figma, or documentation
 
 > `optional` **next**: `string`[]
 
-Defined in: [packages/core/src/types.ts:95](https://github.com/wadakatu/screenbook/blob/b46f17911c7424f697e59b3c5c1e4a9e75b6b7c3/packages/core/src/types.ts#L95)
+Defined in: [packages/core/src/types.ts:95](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L95)
 
 Screen IDs this screen can navigate to (outgoing edges)
 
@@ -168,7 +168,7 @@ Screen IDs this screen can navigate to (outgoing edges)
 
 > `optional` **owner**: `string`[]
 
-Defined in: [packages/core/src/types.ts:67](https://github.com/wadakatu/screenbook/blob/b46f17911c7424f697e59b3c5c1e4a9e75b6b7c3/packages/core/src/types.ts#L67)
+Defined in: [packages/core/src/types.ts:67](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L67)
 
 Team(s) or domain(s) that own this screen
 
@@ -188,7 +188,7 @@ Team(s) or domain(s) that own this screen
 
 > **route**: `string`
 
-Defined in: [packages/core/src/types.ts:60](https://github.com/wadakatu/screenbook/blob/b46f17911c7424f697e59b3c5c1e4a9e75b6b7c3/packages/core/src/types.ts#L60)
+Defined in: [packages/core/src/types.ts:60](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L60)
 
 Route path pattern with optional dynamic segments
 
@@ -212,7 +212,7 @@ Route path pattern with optional dynamic segments
 
 > `optional` **tags**: `string`[]
 
-Defined in: [packages/core/src/types.ts:74](https://github.com/wadakatu/screenbook/blob/b46f17911c7424f697e59b3c5c1e4a9e75b6b7c3/packages/core/src/types.ts#L74)
+Defined in: [packages/core/src/types.ts:74](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L74)
 
 Tags for categorization and filtering in the catalog
 
@@ -232,7 +232,7 @@ Tags for categorization and filtering in the catalog
 
 > **title**: `string`
 
-Defined in: [packages/core/src/types.ts:52](https://github.com/wadakatu/screenbook/blob/b46f17911c7424f697e59b3c5c1e4a9e75b6b7c3/packages/core/src/types.ts#L52)
+Defined in: [packages/core/src/types.ts:52](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L52)
 
 Human-readable title displayed in the screen catalog
 

--- a/docs/src/content/docs/api/type-aliases/ScreenInput.md
+++ b/docs/src/content/docs/api/type-aliases/ScreenInput.md
@@ -7,7 +7,7 @@ title: "ScreenInput"
 
 > **ScreenInput** = [`Screen`](/screenbook/api/interfaces/screen/)
 
-Defined in: [packages/core/src/types.ts:122](https://github.com/wadakatu/screenbook/blob/b46f17911c7424f697e59b3c5c1e4a9e75b6b7c3/packages/core/src/types.ts#L122)
+Defined in: [packages/core/src/types.ts:122](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L122)
 
 Input type for defineScreen function.
 Same as Screen but used for input validation.

--- a/examples/demo/CHANGELOG.md
+++ b/examples/demo/CHANGELOG.md
@@ -1,5 +1,14 @@
 # screenbook-demo
 
+## 0.0.3
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @screenbook/core@1.0.0
+  - @screenbook/cli@1.0.0
+  - @screenbook/ui@1.0.0
+
 ## 0.0.2
 
 ### Patch Changes

--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "screenbook-demo",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,48 @@
 # @screenbook/cli
 
+## 1.0.0
+
+### Major Changes
+
+- # Screenbook v1.0.0
+
+  First stable release of Screenbook - Screen catalog and navigation graph generator for frontend applications.
+
+  ## @screenbook/core
+  - `defineScreen()` function for declaring screen metadata
+  - `defineConfig()` function for configuration
+  - TypeScript types and Zod validation
+
+  ## @screenbook/cli
+  - `screenbook init` - Initialize Screenbook in a project with framework detection
+  - `screenbook generate` - Auto-generate screen.meta.ts files from routes
+  - `screenbook build` - Build screen metadata JSON with validation
+  - `screenbook dev` - Start the development server
+  - `screenbook lint` - Detect routes without screen.meta (CI-ready)
+  - `screenbook impact` - Analyze API dependency impact
+  - `screenbook pr-impact` - Analyze PR changes impact on screens
+  - `screenbook doctor` - Diagnose common setup issues
+
+  ### CLI Features
+  - Circular navigation detection with allowCycles option
+  - Screen reference validation
+  - Progressive adoption mode
+  - Interactive mode for generate command
+  - Colored output with actionable error messages
+
+  ## @screenbook/ui
+  - Screen catalog with search and filtering
+  - Screen detail view with metadata
+  - Navigation graph visualization (Mermaid)
+  - Impact analysis view
+  - Coverage report
+  - Responsive design with accessibility improvements
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @screenbook/core@1.0.0
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@screenbook/cli",
-	"version": "0.1.0",
+	"version": "1.0.0",
 	"description": "CLI for Screenbook - screen catalog and navigation graph generator",
 	"type": "module",
 	"bin": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,43 @@
 # @screenbook/core
 
+## 1.0.0
+
+### Major Changes
+
+- # Screenbook v1.0.0
+
+  First stable release of Screenbook - Screen catalog and navigation graph generator for frontend applications.
+
+  ## @screenbook/core
+  - `defineScreen()` function for declaring screen metadata
+  - `defineConfig()` function for configuration
+  - TypeScript types and Zod validation
+
+  ## @screenbook/cli
+  - `screenbook init` - Initialize Screenbook in a project with framework detection
+  - `screenbook generate` - Auto-generate screen.meta.ts files from routes
+  - `screenbook build` - Build screen metadata JSON with validation
+  - `screenbook dev` - Start the development server
+  - `screenbook lint` - Detect routes without screen.meta (CI-ready)
+  - `screenbook impact` - Analyze API dependency impact
+  - `screenbook pr-impact` - Analyze PR changes impact on screens
+  - `screenbook doctor` - Diagnose common setup issues
+
+  ### CLI Features
+  - Circular navigation detection with allowCycles option
+  - Screen reference validation
+  - Progressive adoption mode
+  - Interactive mode for generate command
+  - Colored output with actionable error messages
+
+  ## @screenbook/ui
+  - Screen catalog with search and filtering
+  - Screen detail view with metadata
+  - Navigation graph visualization (Mermaid)
+  - Impact analysis view
+  - Coverage report
+  - Responsive design with accessibility improvements
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@screenbook/core",
-	"version": "0.1.0",
+	"version": "1.0.0",
 	"description": "Core library for Screenbook - screen metadata definitions and validation",
 	"type": "module",
 	"exports": {

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,48 @@
 # @screenbook/ui
 
+## 1.0.0
+
+### Major Changes
+
+- # Screenbook v1.0.0
+
+  First stable release of Screenbook - Screen catalog and navigation graph generator for frontend applications.
+
+  ## @screenbook/core
+  - `defineScreen()` function for declaring screen metadata
+  - `defineConfig()` function for configuration
+  - TypeScript types and Zod validation
+
+  ## @screenbook/cli
+  - `screenbook init` - Initialize Screenbook in a project with framework detection
+  - `screenbook generate` - Auto-generate screen.meta.ts files from routes
+  - `screenbook build` - Build screen metadata JSON with validation
+  - `screenbook dev` - Start the development server
+  - `screenbook lint` - Detect routes without screen.meta (CI-ready)
+  - `screenbook impact` - Analyze API dependency impact
+  - `screenbook pr-impact` - Analyze PR changes impact on screens
+  - `screenbook doctor` - Diagnose common setup issues
+
+  ### CLI Features
+  - Circular navigation detection with allowCycles option
+  - Screen reference validation
+  - Progressive adoption mode
+  - Interactive mode for generate command
+  - Colored output with actionable error messages
+
+  ## @screenbook/ui
+  - Screen catalog with search and filtering
+  - Screen detail view with metadata
+  - Navigation graph visualization (Mermaid)
+  - Impact analysis view
+  - Coverage report
+  - Responsive design with accessibility improvements
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @screenbook/core@1.0.0
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@screenbook/ui",
-	"version": "0.1.0",
+	"version": "1.0.0",
 	"description": "UI for Screenbook - screen catalog and navigation graph viewer",
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## Screenbook v1.0.0

First stable release of Screenbook - Screen catalog and navigation graph generator for frontend applications.

### Packages

| Package | Version |
|---------|---------|
| @screenbook/core | 1.0.0 |
| @screenbook/cli | 1.0.0 |
| @screenbook/ui | 1.0.0 |

### Highlights

#### @screenbook/core
- `defineScreen()` function for declaring screen metadata
- `defineConfig()` function for configuration
- TypeScript types and Zod validation

#### @screenbook/cli
- `screenbook init` - Initialize with framework detection
- `screenbook generate` - Auto-generate screen.meta.ts (with interactive mode)
- `screenbook build` - Build metadata with validation and cycle detection
- `screenbook dev` - Development server
- `screenbook lint` - CI-ready coverage checking
- `screenbook impact` - API dependency impact analysis
- `screenbook pr-impact` - PR changes impact analysis
- `screenbook doctor` - Setup diagnostics

#### @screenbook/ui
- Screen catalog with search/filter
- Navigation graph visualization (Mermaid)
- Impact analysis view
- Coverage report
- Accessible, responsive design

### Documentation
- Full documentation at https://wadakatu.github.io/screenbook/
- Framework examples (Next.js, Vite + React)

### After Merge
This PR will trigger the npm publish workflow to publish all packages to npm.