### PR TITLE
feat(core,ui): add mock wireframe preview feature

### DIFF
--- a/docs/src/content/docs/api/README.md
+++ b/docs/src/content/docs/api/README.md
@@ -10,13 +10,26 @@ title: "@screenbook/core"
 - [AdoptionConfig](/screenbook/api/interfaces/adoptionconfig/)
 - [Config](/screenbook/api/interfaces/config/)
 - [ConfigInput](/screenbook/api/interfaces/configinput/)
+- [MockButtonElement](/screenbook/api/interfaces/mockbuttonelement/)
+- [MockImageElement](/screenbook/api/interfaces/mockimageelement/)
+- [MockInputElement](/screenbook/api/interfaces/mockinputelement/)
+- [MockLinkElement](/screenbook/api/interfaces/mocklinkelement/)
+- [MockListElement](/screenbook/api/interfaces/mocklistelement/)
+- [MockSection](/screenbook/api/interfaces/mocksection/)
+- [MockTableElement](/screenbook/api/interfaces/mocktableelement/)
+- [MockTextElement](/screenbook/api/interfaces/mocktextelement/)
 - [Screen](/screenbook/api/interfaces/screen/)
+- [ScreenMock](/screenbook/api/interfaces/screenmock/)
 
 ## Type Aliases
 
+- [MockElement](/screenbook/api/type-aliases/mockelement/)
+- [MockElementType](/screenbook/api/type-aliases/mockelementtype/)
+- [MockLayout](/screenbook/api/type-aliases/mocklayout/)
 - [ScreenInput](/screenbook/api/type-aliases/screeninput/)
 
 ## Functions
 
 - [defineConfig](/screenbook/api/functions/defineconfig/)
 - [defineScreen](/screenbook/api/functions/definescreen/)
+- [extractNavigationTargets](/screenbook/api/functions/extractnavigationtargets/)

--- a/docs/src/content/docs/api/functions/defineConfig.md
+++ b/docs/src/content/docs/api/functions/defineConfig.md
@@ -7,7 +7,7 @@ title: "defineConfig"
 
 > **defineConfig**(`input`): [`Config`](/screenbook/api/interfaces/config/)
 
-Defined in: [packages/core/src/defineScreen.ts:43](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/defineScreen.ts#L43)
+Defined in: [packages/core/src/defineScreen.ts:72](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/defineScreen.ts#L72)
 
 Define Screenbook configuration.
 

--- a/docs/src/content/docs/api/functions/defineScreen.md
+++ b/docs/src/content/docs/api/functions/defineScreen.md
@@ -7,9 +7,13 @@ title: "defineScreen"
 
 > **defineScreen**(`input`): [`Screen`](/screenbook/api/interfaces/screen/)
 
-Defined in: [packages/core/src/defineScreen.ts:27](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/defineScreen.ts#L27)
+Defined in: [packages/core/src/defineScreen.ts:46](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/defineScreen.ts#L46)
 
 Define a screen with metadata for the screen catalog.
+
+When a `mock` definition is provided, navigation targets (`navigateTo`, `itemNavigateTo`, `rowNavigateTo`)
+are automatically extracted and used as the `next` field. If `mock` is not provided,
+the manually defined `next` field is used instead.
 
 ## Parameters
 
@@ -24,14 +28,28 @@ Define a screen with metadata for the screen catalog.
 ## Example
 
 ```ts
+// Without mock - manual next definition
 export const screen = defineScreen({
   id: "billing.invoice.detail",
   title: "Invoice Detail",
   route: "/billing/invoices/:id",
-  owner: ["billing"],
-  tags: ["billing", "invoice"],
-  dependsOn: ["InvoiceAPI.getDetail"],
-  entryPoints: ["billing.invoice.list"],
   next: ["billing.invoice.edit"],
 })
+
+// With mock - next is auto-derived from navigateTo
+export const screen = defineScreen({
+  id: "billing.invoice.detail",
+  title: "Invoice Detail",
+  route: "/billing/invoices/:id",
+  mock: {
+    sections: [
+      {
+        elements: [
+          { type: "button", label: "Edit", navigateTo: "billing.invoice.edit" },
+        ],
+      },
+    ],
+  },
+})
+// => next is automatically ["billing.invoice.edit"]
 ```

--- a/docs/src/content/docs/api/functions/extractNavigationTargets.md
+++ b/docs/src/content/docs/api/functions/extractNavigationTargets.md
@@ -1,0 +1,44 @@
+---
+editUrl: false
+next: false
+prev: false
+title: "extractNavigationTargets"
+---
+
+> **extractNavigationTargets**(`mock`): `string`[]
+
+Defined in: packages/core/src/extractNavigationTargets.ts:26
+
+Extracts all navigation targets from a mock definition.
+Collects all `navigateTo`, `itemNavigateTo`, and `rowNavigateTo` values
+from mock elements to determine screen navigation targets.
+
+## Parameters
+
+### mock
+
+[`ScreenMock`](/screenbook/api/interfaces/screenmock/)
+
+The screen mock definition
+
+## Returns
+
+`string`[]
+
+Array of unique screen IDs that this screen can navigate to
+
+## Example
+
+```ts
+const targets = extractNavigationTargets({
+  sections: [
+    {
+      elements: [
+        { type: "button", label: "Edit", navigateTo: "billing.edit" },
+        { type: "link", label: "Back", navigateTo: "billing.list" },
+      ],
+    },
+  ],
+})
+// => ["billing.edit", "billing.list"]
+```

--- a/docs/src/content/docs/api/interfaces/AdoptionConfig.md
+++ b/docs/src/content/docs/api/interfaces/AdoptionConfig.md
@@ -5,7 +5,7 @@ prev: false
 title: "AdoptionConfig"
 ---
 
-Defined in: [packages/core/src/types.ts:161](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L161)
+Defined in: [packages/core/src/types.ts:507](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L507)
 
 Progressive adoption configuration for gradual rollout.
 
@@ -25,7 +25,7 @@ const adoption: AdoptionConfig = {
 
 > `optional` **includePatterns**: `string`[]
 
-Defined in: [packages/core/src/types.ts:177](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L177)
+Defined in: [packages/core/src/types.ts:523](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L523)
 
 Glob patterns to include for coverage checking (progressive mode only)
 
@@ -45,7 +45,7 @@ Glob patterns to include for coverage checking (progressive mode only)
 
 > `optional` **minimumCoverage**: `number`
 
-Defined in: [packages/core/src/types.ts:184](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L184)
+Defined in: [packages/core/src/types.ts:530](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L530)
 
 Minimum coverage percentage required to pass lint (0-100)
 
@@ -65,7 +65,7 @@ Minimum coverage percentage required to pass lint (0-100)
 
 > `optional` **mode**: `"full"` \| `"progressive"`
 
-Defined in: [packages/core/src/types.ts:170](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L170)
+Defined in: [packages/core/src/types.ts:516](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L516)
 
 Adoption mode for screen metadata coverage
 - `"full"`: All routes must have screen.meta.ts (default)

--- a/docs/src/content/docs/api/interfaces/Config.md
+++ b/docs/src/content/docs/api/interfaces/Config.md
@@ -5,7 +5,7 @@ prev: false
 title: "Config"
 ---
 
-Defined in: [packages/core/src/types.ts:200](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L200)
+Defined in: [packages/core/src/types.ts:546](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L546)
 
 Screenbook configuration options.
 
@@ -15,7 +15,7 @@ Screenbook configuration options.
 
 > `optional` **adoption**: [`AdoptionConfig`](/screenbook/api/interfaces/adoptionconfig/)
 
-Defined in: [packages/core/src/types.ts:236](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L236)
+Defined in: [packages/core/src/types.ts:582](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L582)
 
 Progressive adoption configuration for gradual rollout
 
@@ -31,7 +31,7 @@ Progressive adoption configuration for gradual rollout
 
 > **ignore**: `string`[]
 
-Defined in: [packages/core/src/types.ts:230](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L230)
+Defined in: [packages/core/src/types.ts:576](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L576)
 
 Patterns to ignore when scanning (glob patterns).
 Defaults to node_modules and .git directories.
@@ -42,7 +42,7 @@ Defaults to node_modules and .git directories.
 
 > **metaPattern**: `string`
 
-Defined in: [packages/core/src/types.ts:216](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L216)
+Defined in: [packages/core/src/types.ts:562](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L562)
 
 Glob pattern for screen metadata files.
 Supports colocation: place screen.meta.ts alongside your route files.
@@ -69,7 +69,7 @@ Supports colocation: place screen.meta.ts alongside your route files.
 
 > **outDir**: `string`
 
-Defined in: [packages/core/src/types.ts:207](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L207)
+Defined in: [packages/core/src/types.ts:553](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L553)
 
 Output directory for generated files
 
@@ -95,7 +95,7 @@ Output directory for generated files
 
 > `optional` **routesPattern**: `string`
 
-Defined in: [packages/core/src/types.ts:224](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L224)
+Defined in: [packages/core/src/types.ts:570](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L570)
 
 Glob pattern for route files (for generate/lint commands)
 

--- a/docs/src/content/docs/api/interfaces/ConfigInput.md
+++ b/docs/src/content/docs/api/interfaces/ConfigInput.md
@@ -5,7 +5,7 @@ prev: false
 title: "ConfigInput"
 ---
 
-Defined in: [packages/core/src/types.ts:251](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L251)
+Defined in: [packages/core/src/types.ts:597](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L597)
 
 Input type for defineConfig function.
 All fields with defaults are optional in input.
@@ -25,7 +25,7 @@ defineConfig({
 
 > `optional` **adoption**: [`AdoptionConfig`](/screenbook/api/interfaces/adoptionconfig/)
 
-Defined in: [packages/core/src/types.ts:281](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L281)
+Defined in: [packages/core/src/types.ts:627](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L627)
 
 Progressive adoption configuration
 
@@ -35,7 +35,7 @@ Progressive adoption configuration
 
 > `optional` **ignore**: `string`[]
 
-Defined in: [packages/core/src/types.ts:276](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L276)
+Defined in: [packages/core/src/types.ts:622](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L622)
 
 Patterns to ignore when scanning.
 Defaults to node_modules and .git directories.
@@ -46,7 +46,7 @@ Defaults to node_modules and .git directories.
 
 > `optional` **metaPattern**: `string`
 
-Defined in: [packages/core/src/types.ts:264](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L264)
+Defined in: [packages/core/src/types.ts:610](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L610)
 
 Glob pattern for screen metadata files
 
@@ -68,7 +68,7 @@ Glob pattern for screen metadata files
 
 > `optional` **outDir**: `string`
 
-Defined in: [packages/core/src/types.ts:257](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L257)
+Defined in: [packages/core/src/types.ts:603](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L603)
 
 Output directory for generated files
 
@@ -90,7 +90,7 @@ Output directory for generated files
 
 > `optional` **routesPattern**: `string`
 
-Defined in: [packages/core/src/types.ts:270](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L270)
+Defined in: [packages/core/src/types.ts:616](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L616)
 
 Glob pattern for route files (for generate/lint commands)
 

--- a/docs/src/content/docs/api/interfaces/MockButtonElement.md
+++ b/docs/src/content/docs/api/interfaces/MockButtonElement.md
@@ -1,0 +1,84 @@
+---
+editUrl: false
+next: false
+prev: false
+title: "MockButtonElement"
+---
+
+Defined in: [packages/core/src/types.ts:61](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L61)
+
+Button element - can trigger navigation to another screen
+
+## Extends
+
+- `MockElementBase`
+
+## Properties
+
+### label
+
+> **label**: `string`
+
+Defined in: [packages/core/src/types.ts:55](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L55)
+
+Display label or content for the element
+
+#### Examples
+
+```ts
+"Submit"
+```
+
+```ts
+"Search..."
+```
+
+#### Inherited from
+
+`MockElementBase.label`
+
+***
+
+### navigateTo?
+
+> `optional` **navigateTo**: `string`
+
+Defined in: [packages/core/src/types.ts:67](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L67)
+
+Screen ID to navigate to when clicked
+
+#### Example
+
+```ts
+"billing.invoice.edit"
+```
+
+***
+
+### type
+
+> **type**: `"button"`
+
+Defined in: [packages/core/src/types.ts:62](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L62)
+
+Element type identifier
+
+#### Overrides
+
+`MockElementBase.type`
+
+***
+
+### variant?
+
+> `optional` **variant**: `"primary"` \| `"secondary"` \| `"danger"`
+
+Defined in: [packages/core/src/types.ts:72](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L72)
+
+Button variant for styling hints
+
+#### Default
+
+```ts
+"secondary"
+```

--- a/docs/src/content/docs/api/interfaces/MockImageElement.md
+++ b/docs/src/content/docs/api/interfaces/MockImageElement.md
@@ -1,0 +1,72 @@
+---
+editUrl: false
+next: false
+prev: false
+title: "MockImageElement"
+---
+
+Defined in: [packages/core/src/types.ts:118](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L118)
+
+Image placeholder element
+
+## Extends
+
+- `MockElementBase`
+
+## Properties
+
+### aspectRatio?
+
+> `optional` **aspectRatio**: `string`
+
+Defined in: [packages/core/src/types.ts:125](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L125)
+
+Aspect ratio hint for the placeholder
+
+#### Examples
+
+```ts
+"16:9"
+```
+
+```ts
+"1:1"
+```
+
+***
+
+### label
+
+> **label**: `string`
+
+Defined in: [packages/core/src/types.ts:55](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L55)
+
+Display label or content for the element
+
+#### Examples
+
+```ts
+"Submit"
+```
+
+```ts
+"Search..."
+```
+
+#### Inherited from
+
+`MockElementBase.label`
+
+***
+
+### type
+
+> **type**: `"image"`
+
+Defined in: [packages/core/src/types.ts:119](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L119)
+
+Element type identifier
+
+#### Overrides
+
+`MockElementBase.type`

--- a/docs/src/content/docs/api/interfaces/MockInputElement.md
+++ b/docs/src/content/docs/api/interfaces/MockInputElement.md
@@ -1,0 +1,78 @@
+---
+editUrl: false
+next: false
+prev: false
+title: "MockInputElement"
+---
+
+Defined in: [packages/core/src/types.ts:78](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L78)
+
+Input element - text field, textarea, etc.
+
+## Extends
+
+- `MockElementBase`
+
+## Properties
+
+### inputType?
+
+> `optional` **inputType**: `"text"` \| `"email"` \| `"password"` \| `"textarea"` \| `"search"`
+
+Defined in: [packages/core/src/types.ts:88](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L88)
+
+Input subtype hint for rendering
+
+#### Default
+
+```ts
+"text"
+```
+
+***
+
+### label
+
+> **label**: `string`
+
+Defined in: [packages/core/src/types.ts:55](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L55)
+
+Display label or content for the element
+
+#### Examples
+
+```ts
+"Submit"
+```
+
+```ts
+"Search..."
+```
+
+#### Inherited from
+
+`MockElementBase.label`
+
+***
+
+### placeholder?
+
+> `optional` **placeholder**: `string`
+
+Defined in: [packages/core/src/types.ts:83](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L83)
+
+Placeholder text shown when empty
+
+***
+
+### type
+
+> **type**: `"input"`
+
+Defined in: [packages/core/src/types.ts:79](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L79)
+
+Element type identifier
+
+#### Overrides
+
+`MockElementBase.type`

--- a/docs/src/content/docs/api/interfaces/MockLinkElement.md
+++ b/docs/src/content/docs/api/interfaces/MockLinkElement.md
@@ -1,0 +1,68 @@
+---
+editUrl: false
+next: false
+prev: false
+title: "MockLinkElement"
+---
+
+Defined in: [packages/core/src/types.ts:94](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L94)
+
+Link element - can trigger navigation to another screen
+
+## Extends
+
+- `MockElementBase`
+
+## Properties
+
+### label
+
+> **label**: `string`
+
+Defined in: [packages/core/src/types.ts:55](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L55)
+
+Display label or content for the element
+
+#### Examples
+
+```ts
+"Submit"
+```
+
+```ts
+"Search..."
+```
+
+#### Inherited from
+
+`MockElementBase.label`
+
+***
+
+### navigateTo?
+
+> `optional` **navigateTo**: `string`
+
+Defined in: [packages/core/src/types.ts:100](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L100)
+
+Screen ID to navigate to when clicked
+
+#### Example
+
+```ts
+"settings.profile"
+```
+
+***
+
+### type
+
+> **type**: `"link"`
+
+Defined in: [packages/core/src/types.ts:95](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L95)
+
+Element type identifier
+
+#### Overrides
+
+`MockElementBase.type`

--- a/docs/src/content/docs/api/interfaces/MockListElement.md
+++ b/docs/src/content/docs/api/interfaces/MockListElement.md
@@ -1,0 +1,78 @@
+---
+editUrl: false
+next: false
+prev: false
+title: "MockListElement"
+---
+
+Defined in: [packages/core/src/types.ts:131](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L131)
+
+List element - for displaying repeated items
+
+## Extends
+
+- `MockElementBase`
+
+## Properties
+
+### itemCount?
+
+> `optional` **itemCount**: `number`
+
+Defined in: [packages/core/src/types.ts:137](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L137)
+
+Number of placeholder items to show
+
+#### Default
+
+```ts
+3
+```
+
+***
+
+### itemNavigateTo?
+
+> `optional` **itemNavigateTo**: `string`
+
+Defined in: [packages/core/src/types.ts:141](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L141)
+
+Screen ID to navigate to when an item is clicked
+
+***
+
+### label
+
+> **label**: `string`
+
+Defined in: [packages/core/src/types.ts:55](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L55)
+
+Display label or content for the element
+
+#### Examples
+
+```ts
+"Submit"
+```
+
+```ts
+"Search..."
+```
+
+#### Inherited from
+
+`MockElementBase.label`
+
+***
+
+### type
+
+> **type**: `"list"`
+
+Defined in: [packages/core/src/types.ts:132](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L132)
+
+Element type identifier
+
+#### Overrides
+
+`MockElementBase.type`

--- a/docs/src/content/docs/api/interfaces/MockSection.md
+++ b/docs/src/content/docs/api/interfaces/MockSection.md
@@ -1,0 +1,56 @@
+---
+editUrl: false
+next: false
+prev: false
+title: "MockSection"
+---
+
+Defined in: [packages/core/src/types.ts:180](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L180)
+
+Section grouping elements with layout control
+
+## Properties
+
+### elements
+
+> **elements**: [`MockElement`](/screenbook/api/type-aliases/mockelement/)[]
+
+Defined in: [packages/core/src/types.ts:195](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L195)
+
+Elements within this section
+
+***
+
+### layout?
+
+> `optional` **layout**: [`MockLayout`](/screenbook/api/type-aliases/mocklayout/)
+
+Defined in: [packages/core/src/types.ts:191](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L191)
+
+Layout direction for elements in this section
+
+#### Default
+
+```ts
+"vertical"
+```
+
+***
+
+### title?
+
+> `optional` **title**: `string`
+
+Defined in: [packages/core/src/types.ts:186](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L186)
+
+Optional section title displayed as a header
+
+#### Examples
+
+```ts
+"Header"
+```
+
+```ts
+"Actions"
+```

--- a/docs/src/content/docs/api/interfaces/MockTableElement.md
+++ b/docs/src/content/docs/api/interfaces/MockTableElement.md
@@ -1,0 +1,94 @@
+---
+editUrl: false
+next: false
+prev: false
+title: "MockTableElement"
+---
+
+Defined in: [packages/core/src/types.ts:147](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L147)
+
+Table element - for tabular data display
+
+## Extends
+
+- `MockElementBase`
+
+## Properties
+
+### columns?
+
+> `optional` **columns**: `string`[]
+
+Defined in: [packages/core/src/types.ts:153](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L153)
+
+Column headers
+
+#### Example
+
+```ts
+["Name", "Email", "Status"]
+```
+
+***
+
+### label
+
+> **label**: `string`
+
+Defined in: [packages/core/src/types.ts:55](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L55)
+
+Display label or content for the element
+
+#### Examples
+
+```ts
+"Submit"
+```
+
+```ts
+"Search..."
+```
+
+#### Inherited from
+
+`MockElementBase.label`
+
+***
+
+### rowCount?
+
+> `optional` **rowCount**: `number`
+
+Defined in: [packages/core/src/types.ts:158](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L158)
+
+Number of placeholder rows to show
+
+#### Default
+
+```ts
+3
+```
+
+***
+
+### rowNavigateTo?
+
+> `optional` **rowNavigateTo**: `string`
+
+Defined in: [packages/core/src/types.ts:162](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L162)
+
+Screen ID to navigate to when a row is clicked
+
+***
+
+### type
+
+> **type**: `"table"`
+
+Defined in: [packages/core/src/types.ts:148](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L148)
+
+Element type identifier
+
+#### Overrides
+
+`MockElementBase.type`

--- a/docs/src/content/docs/api/interfaces/MockTextElement.md
+++ b/docs/src/content/docs/api/interfaces/MockTextElement.md
@@ -1,0 +1,68 @@
+---
+editUrl: false
+next: false
+prev: false
+title: "MockTextElement"
+---
+
+Defined in: [packages/core/src/types.ts:106](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L106)
+
+Text element - static text display (headings, labels, body text)
+
+## Extends
+
+- `MockElementBase`
+
+## Properties
+
+### label
+
+> **label**: `string`
+
+Defined in: [packages/core/src/types.ts:55](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L55)
+
+Display label or content for the element
+
+#### Examples
+
+```ts
+"Submit"
+```
+
+```ts
+"Search..."
+```
+
+#### Inherited from
+
+`MockElementBase.label`
+
+***
+
+### type
+
+> **type**: `"text"`
+
+Defined in: [packages/core/src/types.ts:107](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L107)
+
+Element type identifier
+
+#### Overrides
+
+`MockElementBase.type`
+
+***
+
+### variant?
+
+> `optional` **variant**: `"heading"` \| `"subheading"` \| `"body"` \| `"caption"`
+
+Defined in: [packages/core/src/types.ts:112](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L112)
+
+Text variant for styling hints
+
+#### Default
+
+```ts
+"body"
+```

--- a/docs/src/content/docs/api/interfaces/Screen.md
+++ b/docs/src/content/docs/api/interfaces/Screen.md
@@ -5,7 +5,7 @@ prev: false
 title: "Screen"
 ---
 
-Defined in: [packages/core/src/types.ts:37](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L37)
+Defined in: [packages/core/src/types.ts:244](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L244)
 
 Screen metadata definition for the screen catalog.
 
@@ -29,7 +29,7 @@ const screen: Screen = {
 
 > `optional` **allowCycles**: `boolean`
 
-Defined in: [packages/core/src/types.ts:103](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L103)
+Defined in: [packages/core/src/types.ts:310](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L310)
 
 Allow circular navigation involving this screen.
 When true, cycles that include this screen will not trigger warnings.
@@ -52,7 +52,7 @@ true
 
 > `optional` **dependsOn**: `string`[]
 
-Defined in: [packages/core/src/types.ts:81](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L81)
+Defined in: [packages/core/src/types.ts:288](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L288)
 
 APIs or services this screen depends on for impact analysis
 
@@ -72,7 +72,7 @@ APIs or services this screen depends on for impact analysis
 
 > `optional` **description**: `string`
 
-Defined in: [packages/core/src/types.ts:109](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L109)
+Defined in: [packages/core/src/types.ts:316](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L316)
 
 Optional description explaining the screen's purpose
 
@@ -88,7 +88,7 @@ Optional description explaining the screen's purpose
 
 > `optional` **entryPoints**: `string`[]
 
-Defined in: [packages/core/src/types.ts:88](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L88)
+Defined in: [packages/core/src/types.ts:295](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L295)
 
 Screen IDs that can navigate to this screen (incoming edges)
 
@@ -108,7 +108,7 @@ Screen IDs that can navigate to this screen (incoming edges)
 
 > **id**: `string`
 
-Defined in: [packages/core/src/types.ts:44](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L44)
+Defined in: [packages/core/src/types.ts:251](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L251)
 
 Unique identifier for the screen using dot notation
 
@@ -132,7 +132,7 @@ Unique identifier for the screen using dot notation
 
 > `optional` **links**: `ScreenLink`[]
 
-Defined in: [packages/core/src/types.ts:115](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L115)
+Defined in: [packages/core/src/types.ts:322](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L322)
 
 Links to external resources like Storybook, Figma, or documentation
 
@@ -144,11 +144,40 @@ Links to external resources like Storybook, Figma, or documentation
 
 ***
 
+### mock?
+
+> `optional` **mock**: [`ScreenMock`](/screenbook/api/interfaces/screenmock/)
+
+Defined in: [packages/core/src/types.ts:345](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L345)
+
+Mock wireframe definition for the screen.
+Used for visual representation in navigation graphs and screen detail pages.
+When defined, navigation targets (navigateTo) are automatically extracted to populate the `next` field.
+
+#### Example
+
+```ts
+mock: {
+  sections: [
+    {
+      title: "Header",
+      layout: "horizontal",
+      elements: [
+        { type: "text", label: "Invoice #123", variant: "heading" },
+        { type: "button", label: "Edit", navigateTo: "billing.invoice.edit" },
+      ],
+    },
+  ],
+}
+```
+
+***
+
 ### next?
 
 > `optional` **next**: `string`[]
 
-Defined in: [packages/core/src/types.ts:95](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L95)
+Defined in: [packages/core/src/types.ts:302](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L302)
 
 Screen IDs this screen can navigate to (outgoing edges)
 
@@ -168,7 +197,7 @@ Screen IDs this screen can navigate to (outgoing edges)
 
 > `optional` **owner**: `string`[]
 
-Defined in: [packages/core/src/types.ts:67](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L67)
+Defined in: [packages/core/src/types.ts:274](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L274)
 
 Team(s) or domain(s) that own this screen
 
@@ -188,7 +217,7 @@ Team(s) or domain(s) that own this screen
 
 > **route**: `string`
 
-Defined in: [packages/core/src/types.ts:60](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L60)
+Defined in: [packages/core/src/types.ts:267](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L267)
 
 Route path pattern with optional dynamic segments
 
@@ -212,7 +241,7 @@ Route path pattern with optional dynamic segments
 
 > `optional` **tags**: `string`[]
 
-Defined in: [packages/core/src/types.ts:74](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L74)
+Defined in: [packages/core/src/types.ts:281](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L281)
 
 Tags for categorization and filtering in the catalog
 
@@ -232,7 +261,7 @@ Tags for categorization and filtering in the catalog
 
 > **title**: `string`
 
-Defined in: [packages/core/src/types.ts:52](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L52)
+Defined in: [packages/core/src/types.ts:259](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L259)
 
 Human-readable title displayed in the screen catalog
 

--- a/docs/src/content/docs/api/interfaces/ScreenMock.md
+++ b/docs/src/content/docs/api/interfaces/ScreenMock.md
@@ -1,0 +1,37 @@
+---
+editUrl: false
+next: false
+prev: false
+title: "ScreenMock"
+---
+
+Defined in: [packages/core/src/types.ts:217](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L217)
+
+Complete mock definition for a screen wireframe
+
+## Example
+
+```ts
+const mock: ScreenMock = {
+  sections: [
+    {
+      title: "Header",
+      layout: "horizontal",
+      elements: [
+        { type: "text", label: "Invoice #123", variant: "heading" },
+        { type: "button", label: "Edit", navigateTo: "billing.invoice.edit" },
+      ],
+    },
+  ],
+}
+```
+
+## Properties
+
+### sections
+
+> **sections**: [`MockSection`](/screenbook/api/interfaces/mocksection/)[]
+
+Defined in: [packages/core/src/types.ts:221](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L221)
+
+Sections that compose the screen wireframe

--- a/docs/src/content/docs/api/type-aliases/MockElement.md
+++ b/docs/src/content/docs/api/type-aliases/MockElement.md
@@ -1,0 +1,12 @@
+---
+editUrl: false
+next: false
+prev: false
+title: "MockElement"
+---
+
+> **MockElement** = [`MockButtonElement`](/screenbook/api/interfaces/mockbuttonelement/) \| [`MockInputElement`](/screenbook/api/interfaces/mockinputelement/) \| [`MockLinkElement`](/screenbook/api/interfaces/mocklinkelement/) \| [`MockTextElement`](/screenbook/api/interfaces/mocktextelement/) \| [`MockImageElement`](/screenbook/api/interfaces/mockimageelement/) \| [`MockListElement`](/screenbook/api/interfaces/mocklistelement/) \| [`MockTableElement`](/screenbook/api/interfaces/mocktableelement/)
+
+Defined in: [packages/core/src/types.ts:168](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L168)
+
+Union type for all mock elements

--- a/docs/src/content/docs/api/type-aliases/MockElementType.md
+++ b/docs/src/content/docs/api/type-aliases/MockElementType.md
@@ -1,0 +1,12 @@
+---
+editUrl: false
+next: false
+prev: false
+title: "MockElementType"
+---
+
+> **MockElementType** = `"button"` \| `"input"` \| `"link"` \| `"text"` \| `"image"` \| `"list"` \| `"table"`
+
+Defined in: [packages/core/src/types.ts:33](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L33)
+
+Element types supported in mock definitions

--- a/docs/src/content/docs/api/type-aliases/MockLayout.md
+++ b/docs/src/content/docs/api/type-aliases/MockLayout.md
@@ -1,0 +1,12 @@
+---
+editUrl: false
+next: false
+prev: false
+title: "MockLayout"
+---
+
+> **MockLayout** = `"vertical"` \| `"horizontal"`
+
+Defined in: [packages/core/src/types.ts:28](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L28)
+
+Layout direction for mock sections

--- a/docs/src/content/docs/api/type-aliases/ScreenInput.md
+++ b/docs/src/content/docs/api/type-aliases/ScreenInput.md
@@ -7,7 +7,7 @@ title: "ScreenInput"
 
 > **ScreenInput** = [`Screen`](/screenbook/api/interfaces/screen/)
 
-Defined in: [packages/core/src/types.ts:122](https://github.com/wadakatu/screenbook/blob/80ed6bad308e61bc775211dba9e5241b3fd47533/packages/core/src/types.ts#L122)
+Defined in: [packages/core/src/types.ts:352](https://github.com/wadakatu/screenbook/blob/7458caa0341a34cbc04a2da58e98f73ab73b4d43/packages/core/src/types.ts#L352)
 
 Input type for defineScreen function.
 Same as Screen but used for input validation.

--- a/examples/vite-react/src/pages/Dashboard/screen.meta.ts
+++ b/examples/vite-react/src/pages/Dashboard/screen.meta.ts
@@ -8,6 +8,39 @@ export const screen = defineScreen({
 	tags: ["analytics", "dashboard"],
 	description: "Main dashboard showing analytics and metrics",
 	entryPoints: ["home"],
-	next: ["settings"],
 	dependsOn: ["AnalyticsAPI.getStats", "AnalyticsAPI.getRevenue"],
+
+	mock: {
+		sections: [
+			{
+				title: "Header",
+				layout: "horizontal",
+				elements: [
+					{ type: "text", label: "Dashboard", variant: "heading" },
+					{ type: "button", label: "Settings", navigateTo: "settings" },
+				],
+			},
+			{
+				title: "Stats",
+				layout: "horizontal",
+				elements: [
+					{ type: "text", label: "Total Users: 1,234" },
+					{ type: "text", label: "Revenue: $56,789" },
+					{ type: "text", label: "Active Sessions: 89" },
+				],
+			},
+			{
+				title: "Analytics",
+				elements: [
+					{ type: "image", label: "Chart", aspectRatio: "16:9" },
+					{
+						type: "table",
+						label: "Recent Activity",
+						columns: ["User", "Action", "Time"],
+						rowCount: 5,
+					},
+				],
+			},
+		],
+	},
 })

--- a/examples/vite-react/src/pages/Home/screen.meta.ts
+++ b/examples/vite-react/src/pages/Home/screen.meta.ts
@@ -7,6 +7,34 @@ export const screen = defineScreen({
 	owner: ["platform"],
 	tags: ["navigation"],
 	description: "Landing page with navigation to main sections",
-	next: ["dashboard", "settings"],
 	dependsOn: [],
+
+	mock: {
+		sections: [
+			{
+				title: "Header",
+				layout: "horizontal",
+				elements: [
+					{ type: "text", label: "Screenbook Demo", variant: "heading" },
+					{ type: "link", label: "Settings", navigateTo: "settings" },
+				],
+			},
+			{
+				title: "Hero",
+				elements: [
+					{ type: "text", label: "Welcome to Screenbook", variant: "subheading" },
+					{ type: "text", label: "A screen catalog and navigation graph generator" },
+					{ type: "image", label: "Hero Image", aspectRatio: "16:9" },
+				],
+			},
+			{
+				title: "Actions",
+				layout: "horizontal",
+				elements: [
+					{ type: "button", label: "View Dashboard", variant: "primary", navigateTo: "dashboard" },
+					{ type: "button", label: "Settings", navigateTo: "settings" },
+				],
+			},
+		],
+	},
 })

--- a/examples/vite-react/src/pages/Settings/screen.meta.ts
+++ b/examples/vite-react/src/pages/Settings/screen.meta.ts
@@ -8,6 +8,43 @@ export const screen = defineScreen({
 	tags: ["settings", "account"],
 	description: "User account settings and preferences",
 	entryPoints: ["home", "dashboard"],
-	next: [],
 	dependsOn: ["UserAPI.getProfile", "UserAPI.updateProfile"],
+
+	mock: {
+		sections: [
+			{
+				title: "Header",
+				elements: [
+					{ type: "text", label: "Settings", variant: "heading" },
+				],
+			},
+			{
+				title: "Profile",
+				elements: [
+					{ type: "input", label: "Name", placeholder: "Enter your name" },
+					{ type: "input", label: "Email", inputType: "email", placeholder: "your@email.com" },
+					{ type: "image", label: "Avatar", aspectRatio: "1:1" },
+				],
+			},
+			{
+				title: "Preferences",
+				elements: [
+					{
+						type: "list",
+						label: "Notification Settings",
+						itemCount: 3,
+					},
+				],
+			},
+			{
+				title: "Actions",
+				layout: "horizontal",
+				elements: [
+					{ type: "button", label: "Save Changes", variant: "primary" },
+					{ type: "button", label: "Cancel" },
+					{ type: "button", label: "Delete Account", variant: "danger" },
+				],
+			},
+		],
+	},
 })

--- a/packages/core/src/__tests__/defineScreen.test.ts
+++ b/packages/core/src/__tests__/defineScreen.test.ts
@@ -96,4 +96,181 @@ describe("defineScreen", () => {
 		expect(screen.owner).toEqual([])
 		expect(screen.tags).toEqual([])
 	})
+
+	describe("mock feature", () => {
+		it("should accept a screen with mock definition", () => {
+			const screen = defineScreen({
+				id: "billing.invoice.detail",
+				title: "Invoice Detail",
+				route: "/billing/invoices/:id",
+				mock: {
+					sections: [
+						{
+							title: "Header",
+							layout: "horizontal",
+							elements: [
+								{ type: "text", label: "Invoice #123", variant: "heading" },
+								{ type: "button", label: "Edit", navigateTo: "billing.invoice.edit" },
+							],
+						},
+					],
+				},
+			})
+
+			expect(screen.mock).toBeDefined()
+			expect(screen.mock?.sections).toHaveLength(1)
+			expect(screen.mock?.sections[0]?.title).toBe("Header")
+		})
+
+		it("should auto-derive next from mock navigateTo", () => {
+			const screen = defineScreen({
+				id: "billing.invoice.detail",
+				title: "Invoice Detail",
+				route: "/billing/invoices/:id",
+				mock: {
+					sections: [
+						{
+							elements: [
+								{ type: "button", label: "Edit", navigateTo: "billing.invoice.edit" },
+								{ type: "button", label: "Pay", navigateTo: "billing.payment.start" },
+								{ type: "link", label: "Back", navigateTo: "billing.invoice.list" },
+							],
+						},
+					],
+				},
+			})
+
+			expect(screen.next).toBeDefined()
+			expect(screen.next).toContain("billing.invoice.edit")
+			expect(screen.next).toContain("billing.payment.start")
+			expect(screen.next).toContain("billing.invoice.list")
+		})
+
+		it("should use manual next when mock is not provided", () => {
+			const screen = defineScreen({
+				id: "billing.invoice.detail",
+				title: "Invoice Detail",
+				route: "/billing/invoices/:id",
+				next: ["billing.invoice.edit"],
+			})
+
+			expect(screen.next).toEqual(["billing.invoice.edit"])
+		})
+
+		it("should override manual next with mock navigateTo when mock is provided", () => {
+			const screen = defineScreen({
+				id: "billing.invoice.detail",
+				title: "Invoice Detail",
+				route: "/billing/invoices/:id",
+				next: ["manual.target"], // This should be overridden
+				mock: {
+					sections: [
+						{
+							elements: [
+								{ type: "button", label: "Edit", navigateTo: "billing.invoice.edit" },
+							],
+						},
+					],
+				},
+			})
+
+			expect(screen.next).toEqual(["billing.invoice.edit"])
+			expect(screen.next).not.toContain("manual.target")
+		})
+
+		it("should not set next when mock has no navigation targets", () => {
+			const screen = defineScreen({
+				id: "static.page",
+				title: "Static Page",
+				route: "/static",
+				mock: {
+					sections: [
+						{
+							elements: [
+								{ type: "text", label: "Hello World", variant: "heading" },
+								{ type: "text", label: "Some content" },
+							],
+						},
+					],
+				},
+			})
+
+			expect(screen.next).toBeUndefined()
+		})
+
+		it("should validate mock element types", () => {
+			const screen = defineScreen({
+				id: "test",
+				title: "Test",
+				route: "/test",
+				mock: {
+					sections: [
+						{
+							elements: [
+								{ type: "button", label: "Button", variant: "primary" },
+								{ type: "input", label: "Input", inputType: "email" },
+								{ type: "link", label: "Link" },
+								{ type: "text", label: "Text", variant: "heading" },
+								{ type: "image", label: "Image", aspectRatio: "16:9" },
+								{ type: "list", label: "List", itemCount: 5 },
+								{ type: "table", label: "Table", columns: ["A", "B"], rowCount: 3 },
+							],
+						},
+					],
+				},
+			})
+
+			expect(screen.mock?.sections[0]?.elements).toHaveLength(7)
+		})
+
+		it("should throw error for invalid mock element type", () => {
+			expect(() =>
+				defineScreen({
+					id: "test",
+					title: "Test",
+					route: "/test",
+					mock: {
+						sections: [
+							{
+								elements: [
+									// @ts-expect-error - Testing invalid type
+									{ type: "invalid", label: "Invalid" },
+								],
+							},
+						],
+					},
+				}),
+			).toThrow()
+		})
+
+		it("should throw error for empty sections array", () => {
+			expect(() =>
+				defineScreen({
+					id: "test",
+					title: "Test",
+					route: "/test",
+					mock: {
+						sections: [],
+					},
+				}),
+			).toThrow()
+		})
+
+		it("should throw error for empty elements array in section", () => {
+			expect(() =>
+				defineScreen({
+					id: "test",
+					title: "Test",
+					route: "/test",
+					mock: {
+						sections: [
+							{
+								elements: [],
+							},
+						],
+					},
+				}),
+			).toThrow()
+		})
+	})
 })

--- a/packages/core/src/__tests__/extractNavigationTargets.test.ts
+++ b/packages/core/src/__tests__/extractNavigationTargets.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest"
+import { extractNavigationTargets } from "../extractNavigationTargets.js"
+import type { ScreenMock } from "../types.js"
+
+describe("extractNavigationTargets", () => {
+	it("should extract navigateTo from button elements", () => {
+		const mock: ScreenMock = {
+			sections: [
+				{
+					elements: [
+						{ type: "button", label: "Edit", navigateTo: "billing.edit" },
+						{ type: "button", label: "Delete", navigateTo: "billing.delete" },
+					],
+				},
+			],
+		}
+
+		const targets = extractNavigationTargets(mock)
+		expect(targets).toEqual(["billing.edit", "billing.delete"])
+	})
+
+	it("should extract navigateTo from link elements", () => {
+		const mock: ScreenMock = {
+			sections: [
+				{
+					elements: [
+						{ type: "link", label: "Back", navigateTo: "billing.list" },
+					],
+				},
+			],
+		}
+
+		const targets = extractNavigationTargets(mock)
+		expect(targets).toEqual(["billing.list"])
+	})
+
+	it("should extract itemNavigateTo from list elements", () => {
+		const mock: ScreenMock = {
+			sections: [
+				{
+					elements: [
+						{ type: "list", label: "Items", itemNavigateTo: "item.detail" },
+					],
+				},
+			],
+		}
+
+		const targets = extractNavigationTargets(mock)
+		expect(targets).toEqual(["item.detail"])
+	})
+
+	it("should extract rowNavigateTo from table elements", () => {
+		const mock: ScreenMock = {
+			sections: [
+				{
+					elements: [
+						{
+							type: "table",
+							label: "Users",
+							columns: ["Name", "Email"],
+							rowNavigateTo: "user.detail",
+						},
+					],
+				},
+			],
+		}
+
+		const targets = extractNavigationTargets(mock)
+		expect(targets).toEqual(["user.detail"])
+	})
+
+	it("should extract from multiple sections", () => {
+		const mock: ScreenMock = {
+			sections: [
+				{
+					title: "Header",
+					elements: [
+						{ type: "button", label: "Edit", navigateTo: "billing.edit" },
+					],
+				},
+				{
+					title: "Footer",
+					elements: [
+						{ type: "link", label: "Back", navigateTo: "billing.list" },
+					],
+				},
+			],
+		}
+
+		const targets = extractNavigationTargets(mock)
+		expect(targets).toContain("billing.edit")
+		expect(targets).toContain("billing.list")
+	})
+
+	it("should deduplicate navigation targets", () => {
+		const mock: ScreenMock = {
+			sections: [
+				{
+					elements: [
+						{ type: "button", label: "Edit", navigateTo: "billing.edit" },
+						{ type: "link", label: "Edit Link", navigateTo: "billing.edit" },
+					],
+				},
+			],
+		}
+
+		const targets = extractNavigationTargets(mock)
+		expect(targets).toEqual(["billing.edit"])
+	})
+
+	it("should ignore elements without navigation", () => {
+		const mock: ScreenMock = {
+			sections: [
+				{
+					elements: [
+						{ type: "text", label: "Title", variant: "heading" },
+						{ type: "input", label: "Email", inputType: "email" },
+						{ type: "image", label: "Logo", aspectRatio: "16:9" },
+						{ type: "button", label: "Submit" }, // No navigateTo
+					],
+				},
+			],
+		}
+
+		const targets = extractNavigationTargets(mock)
+		expect(targets).toEqual([])
+	})
+
+	it("should handle mixed elements with and without navigation", () => {
+		const mock: ScreenMock = {
+			sections: [
+				{
+					elements: [
+						{ type: "text", label: "Invoice Detail", variant: "heading" },
+						{ type: "button", label: "Edit", navigateTo: "billing.edit" },
+						{ type: "input", label: "Notes" },
+						{ type: "button", label: "Pay", variant: "primary", navigateTo: "payment.start" },
+						{ type: "link", label: "Back", navigateTo: "billing.list" },
+					],
+				},
+			],
+		}
+
+		const targets = extractNavigationTargets(mock)
+		expect(targets).toHaveLength(3)
+		expect(targets).toContain("billing.edit")
+		expect(targets).toContain("payment.start")
+		expect(targets).toContain("billing.list")
+	})
+})

--- a/packages/core/src/defineScreen.ts
+++ b/packages/core/src/defineScreen.ts
@@ -1,3 +1,4 @@
+import { extractNavigationTargets } from "./extractNavigationTargets.js"
 import {
 	type Config,
 	type ConfigInput,
@@ -10,22 +11,50 @@ import {
 /**
  * Define a screen with metadata for the screen catalog.
  *
+ * When a `mock` definition is provided, navigation targets (`navigateTo`, `itemNavigateTo`, `rowNavigateTo`)
+ * are automatically extracted and used as the `next` field. If `mock` is not provided,
+ * the manually defined `next` field is used instead.
+ *
  * @example
  * ```ts
+ * // Without mock - manual next definition
  * export const screen = defineScreen({
  *   id: "billing.invoice.detail",
  *   title: "Invoice Detail",
  *   route: "/billing/invoices/:id",
- *   owner: ["billing"],
- *   tags: ["billing", "invoice"],
- *   dependsOn: ["InvoiceAPI.getDetail"],
- *   entryPoints: ["billing.invoice.list"],
  *   next: ["billing.invoice.edit"],
  * })
+ *
+ * // With mock - next is auto-derived from navigateTo
+ * export const screen = defineScreen({
+ *   id: "billing.invoice.detail",
+ *   title: "Invoice Detail",
+ *   route: "/billing/invoices/:id",
+ *   mock: {
+ *     sections: [
+ *       {
+ *         elements: [
+ *           { type: "button", label: "Edit", navigateTo: "billing.invoice.edit" },
+ *         ],
+ *       },
+ *     ],
+ *   },
+ * })
+ * // => next is automatically ["billing.invoice.edit"]
  * ```
  */
 export function defineScreen(input: ScreenInput): Screen {
-	return screenSchema.parse(input)
+	const validated = screenSchema.parse(input)
+
+	// Auto-derive next from mock if mock exists
+	if (validated.mock) {
+		const mockTargets = extractNavigationTargets(validated.mock)
+		if (mockTargets.length > 0) {
+			validated.next = mockTargets
+		}
+	}
+
+	return validated
 }
 
 /**

--- a/packages/core/src/extractNavigationTargets.ts
+++ b/packages/core/src/extractNavigationTargets.ts
@@ -1,0 +1,47 @@
+import type { ScreenMock } from "./types.js"
+
+/**
+ * Extracts all navigation targets from a mock definition.
+ * Collects all `navigateTo`, `itemNavigateTo`, and `rowNavigateTo` values
+ * from mock elements to determine screen navigation targets.
+ *
+ * @param mock - The screen mock definition
+ * @returns Array of unique screen IDs that this screen can navigate to
+ *
+ * @example
+ * ```ts
+ * const targets = extractNavigationTargets({
+ *   sections: [
+ *     {
+ *       elements: [
+ *         { type: "button", label: "Edit", navigateTo: "billing.edit" },
+ *         { type: "link", label: "Back", navigateTo: "billing.list" },
+ *       ],
+ *     },
+ *   ],
+ * })
+ * // => ["billing.edit", "billing.list"]
+ * ```
+ */
+export function extractNavigationTargets(mock: ScreenMock): string[] {
+	const targets = new Set<string>()
+
+	for (const section of mock.sections) {
+		for (const element of section.elements) {
+			// Button and Link elements have navigateTo
+			if ("navigateTo" in element && element.navigateTo) {
+				targets.add(element.navigateTo)
+			}
+			// List elements have itemNavigateTo
+			if ("itemNavigateTo" in element && element.itemNavigateTo) {
+				targets.add(element.itemNavigateTo)
+			}
+			// Table elements have rowNavigateTo
+			if ("rowNavigateTo" in element && element.rowNavigateTo) {
+				targets.add(element.rowNavigateTo)
+			}
+		}
+	}
+
+	return Array.from(targets)
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,11 +1,26 @@
 export { defineConfig, defineScreen } from "./defineScreen.js"
+export { extractNavigationTargets } from "./extractNavigationTargets.js"
 export {
 	type AdoptionConfig,
 	adoptionSchema,
 	type Config,
 	type ConfigInput,
 	configSchema,
+	// Mock types
+	type MockButtonElement,
+	type MockElement,
+	type MockElementType,
+	type MockImageElement,
+	type MockInputElement,
+	type MockLayout,
+	type MockLinkElement,
+	type MockListElement,
+	type MockSection,
+	type MockTableElement,
+	type MockTextElement,
 	type Screen,
 	type ScreenInput,
+	type ScreenMock,
+	screenMockSchema,
 	screenSchema,
 } from "./types.js"

--- a/packages/ui/src/components/MockPreview.astro
+++ b/packages/ui/src/components/MockPreview.astro
@@ -1,0 +1,544 @@
+---
+import type { ScreenMock, MockElement, MockSection } from "@screenbook/core"
+
+interface Props {
+	mock: ScreenMock
+	title?: string
+}
+
+const { mock, title } = Astro.props
+
+function getNavigateTo(element: MockElement): string | undefined {
+	if ("navigateTo" in element) return element.navigateTo
+	if ("itemNavigateTo" in element) return element.itemNavigateTo
+	if ("rowNavigateTo" in element) return element.rowNavigateTo
+	return undefined
+}
+---
+
+<div class="mock-preview">
+	<div class="mock-device">
+		{title && (
+			<div class="mock-device-header">
+				<span class="mock-device-title">{title}</span>
+			</div>
+		)}
+		<div class="mock-device-screen">
+			{mock.sections.map((section: MockSection) => (
+				<div class="mock-section">
+					{section.title && (
+						<div class="mock-section-header">
+							<span class="mock-section-title">{section.title}</span>
+						</div>
+					)}
+					<div class={`mock-section-content ${section.layout === "horizontal" ? "layout-horizontal" : "layout-vertical"}`}>
+						{section.elements.map((element: MockElement) => {
+							const navigateTo = getNavigateTo(element)
+
+							return (
+								<div class={`mock-element`}>
+									{element.type === "button" && (
+										<div class={`mock-btn mock-btn-${element.variant || "secondary"}`}>
+											<span class="mock-btn-text">{element.label}</span>
+											{navigateTo && (
+												<span class="mock-nav-badge" title={`→ ${navigateTo}`}>
+													→ {navigateTo}
+												</span>
+											)}
+										</div>
+									)}
+
+									{element.type === "input" && (
+										<div class="mock-input-field">
+											<span class="mock-input-label">{element.label}</span>
+											<div class="mock-input-box">
+												<span class="mock-input-placeholder">{element.placeholder || "..."}</span>
+											</div>
+										</div>
+									)}
+
+									{element.type === "link" && (
+										<div class="mock-link-element">
+											<span class="mock-link-text">{element.label}</span>
+											{navigateTo && (
+												<span class="mock-nav-badge small" title={`→ ${navigateTo}`}>
+													→ {navigateTo}
+												</span>
+											)}
+										</div>
+									)}
+
+									{element.type === "text" && (
+										<div class={`mock-text-element mock-text-${element.variant || "body"}`}>
+											{element.variant === "heading" && <div class="mock-text-bar heading" />}
+											{element.variant === "subheading" && <div class="mock-text-bar subheading" />}
+											<span>{element.label}</span>
+										</div>
+									)}
+
+									{element.type === "image" && (
+										<div
+											class="mock-image-element"
+											style={element.aspectRatio ? `aspect-ratio: ${element.aspectRatio.replace(":", "/")}` : "aspect-ratio: 16/9"}
+										>
+											<div class="mock-image-icon">
+												<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+													<rect width="18" height="18" x="3" y="3" rx="2" ry="2" />
+													<circle cx="9" cy="9" r="2" />
+													<path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21" />
+												</svg>
+											</div>
+											<span class="mock-image-label">{element.label}</span>
+										</div>
+									)}
+
+									{element.type === "list" && (
+										<div class="mock-list-element">
+											<div class="mock-list-header">{element.label}</div>
+											<div class="mock-list-items">
+												{Array.from({ length: element.itemCount || 3 }).map((_, i) => (
+													<div class="mock-list-item">
+														<div class="mock-list-item-content">
+															<div class="mock-list-item-bar" />
+															<div class="mock-list-item-bar short" />
+														</div>
+														{navigateTo && (
+															<span class="mock-list-arrow">›</span>
+														)}
+													</div>
+												))}
+											</div>
+										</div>
+									)}
+
+									{element.type === "table" && (
+										<div class="mock-table-element">
+											<div class="mock-table-header-row">
+												{(element.columns || ["Col 1", "Col 2", "Col 3"]).map((col) => (
+													<div class="mock-table-header-cell">{col}</div>
+												))}
+											</div>
+											<div class="mock-table-body">
+												{Array.from({ length: element.rowCount || 3 }).map((_, i) => (
+													<div class="mock-table-row">
+														{(element.columns || ["Col 1", "Col 2", "Col 3"]).map((_, j) => (
+															<div class="mock-table-cell">
+																<div class="mock-table-cell-bar" />
+															</div>
+														))}
+														{navigateTo && (
+															<span class="mock-table-arrow">›</span>
+														)}
+													</div>
+												))}
+											</div>
+										</div>
+									)}
+								</div>
+							)
+						})}
+					</div>
+				</div>
+			))}
+		</div>
+	</div>
+</div>
+
+<style>
+	.mock-preview {
+		margin-top: 16px;
+	}
+
+	/* Device Frame */
+	.mock-device {
+		background: #1a1f2e;
+		border: 2px solid #2d3548;
+		border-radius: 16px;
+		overflow: hidden;
+		box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+	}
+
+	.mock-device-header {
+		background: linear-gradient(135deg, #14b8a6 0%, #0d9488 100%);
+		padding: 10px 16px;
+		display: flex;
+		align-items: center;
+	}
+
+	.mock-device-title {
+		font-size: 13px;
+		font-weight: 600;
+		color: white;
+		letter-spacing: 0.02em;
+	}
+
+	.mock-device-screen {
+		padding: 16px;
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+		background: #141822;
+	}
+
+	/* Sections */
+	.mock-section {
+		background: #1e2433;
+		border-radius: 10px;
+		overflow: hidden;
+	}
+
+	.mock-section-header {
+		background: rgba(20, 184, 166, 0.15);
+		padding: 8px 14px;
+		border-bottom: 1px solid rgba(20, 184, 166, 0.2);
+	}
+
+	.mock-section-title {
+		font-size: 11px;
+		font-weight: 600;
+		color: #14b8a6;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+	}
+
+	.mock-section-content {
+		padding: 14px;
+		display: flex;
+		gap: 10px;
+	}
+
+	.mock-section-content.layout-vertical {
+		flex-direction: column;
+	}
+
+	.mock-section-content.layout-horizontal {
+		flex-direction: row;
+		flex-wrap: wrap;
+	}
+
+	.mock-element {
+		flex: 1;
+		min-width: 0;
+	}
+
+	.layout-horizontal .mock-element {
+		min-width: 120px;
+	}
+
+	/* Button */
+	.mock-btn {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 8px;
+		padding: 10px 14px;
+		border-radius: 8px;
+		font-size: 12px;
+		font-weight: 600;
+		cursor: default;
+		transition: transform 0.15s ease;
+	}
+
+	.mock-btn:hover {
+		transform: translateY(-1px);
+	}
+
+	.mock-btn-primary {
+		background: linear-gradient(135deg, #14b8a6 0%, #0d9488 100%);
+		color: white;
+		box-shadow: 0 2px 8px rgba(20, 184, 166, 0.3);
+	}
+
+	.mock-btn-secondary {
+		background: #2d3548;
+		color: #94a3b8;
+		border: 1px solid #3d4660;
+	}
+
+	.mock-btn-danger {
+		background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
+		color: white;
+		box-shadow: 0 2px 8px rgba(239, 68, 68, 0.3);
+	}
+
+	.mock-btn-text {
+		flex: 1;
+	}
+
+	/* Input */
+	.mock-input-field {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+	}
+
+	.mock-input-label {
+		font-size: 11px;
+		font-weight: 500;
+		color: #64748b;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+	}
+
+	.mock-input-box {
+		background: #0f1219;
+		border: 1px solid #2d3548;
+		border-radius: 6px;
+		padding: 10px 12px;
+	}
+
+	.mock-input-placeholder {
+		font-size: 12px;
+		color: #475569;
+	}
+
+	/* Link */
+	.mock-link-element {
+		display: inline-flex;
+		align-items: center;
+		gap: 8px;
+		padding: 6px 0;
+	}
+
+	.mock-link-text {
+		font-size: 12px;
+		color: #14b8a6;
+		text-decoration: underline;
+		text-underline-offset: 2px;
+	}
+
+	/* Text */
+	.mock-text-element {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+
+	.mock-text-element span {
+		color: #94a3b8;
+	}
+
+	.mock-text-heading span {
+		font-size: 16px;
+		font-weight: 700;
+		color: #e2e8f0;
+	}
+
+	.mock-text-subheading span {
+		font-size: 13px;
+		font-weight: 600;
+		color: #cbd5e1;
+	}
+
+	.mock-text-body span {
+		font-size: 12px;
+		color: #94a3b8;
+	}
+
+	.mock-text-caption span {
+		font-size: 11px;
+		color: #64748b;
+	}
+
+	.mock-text-bar {
+		height: 4px;
+		background: linear-gradient(90deg, #3d4660 0%, #2d3548 100%);
+		border-radius: 2px;
+	}
+
+	.mock-text-bar.heading {
+		width: 60%;
+		height: 6px;
+		background: linear-gradient(90deg, #14b8a6 0%, #0d9488 100%);
+	}
+
+	.mock-text-bar.subheading {
+		width: 45%;
+		height: 5px;
+	}
+
+	/* Image */
+	.mock-image-element {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 8px;
+		background: linear-gradient(135deg, #1e2433 0%, #252d40 100%);
+		border: 2px dashed #3d4660;
+		border-radius: 10px;
+		min-height: 60px;
+		max-height: 150px;
+		padding: 16px;
+	}
+
+	.mock-image-icon {
+		color: #475569;
+		opacity: 0.6;
+	}
+
+	.mock-image-label {
+		font-size: 11px;
+		color: #64748b;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+	}
+
+	/* List */
+	.mock-list-element {
+		background: #0f1219;
+		border-radius: 8px;
+		overflow: hidden;
+	}
+
+	.mock-list-header {
+		font-size: 11px;
+		font-weight: 600;
+		color: #64748b;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		padding: 10px 12px;
+		background: #1a1f2e;
+		border-bottom: 1px solid #2d3548;
+	}
+
+	.mock-list-items {
+		display: flex;
+		flex-direction: column;
+	}
+
+	.mock-list-item {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 10px 12px;
+		border-bottom: 1px solid #1e2433;
+	}
+
+	.mock-list-item:last-child {
+		border-bottom: none;
+	}
+
+	.mock-list-item-content {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		flex: 1;
+	}
+
+	.mock-list-item-bar {
+		height: 4px;
+		background: #2d3548;
+		border-radius: 2px;
+		width: 70%;
+	}
+
+	.mock-list-item-bar.short {
+		width: 40%;
+		opacity: 0.6;
+	}
+
+	.mock-list-arrow {
+		font-size: 16px;
+		color: #475569;
+		font-weight: 300;
+	}
+
+	/* Table */
+	.mock-table-element {
+		background: #0f1219;
+		border-radius: 8px;
+		overflow: hidden;
+		border: 1px solid #2d3548;
+	}
+
+	.mock-table-header-row {
+		display: flex;
+		background: #1a1f2e;
+		border-bottom: 1px solid #2d3548;
+	}
+
+	.mock-table-header-cell {
+		flex: 1;
+		padding: 10px 12px;
+		font-size: 11px;
+		font-weight: 600;
+		color: #64748b;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+	}
+
+	.mock-table-body {
+		display: flex;
+		flex-direction: column;
+	}
+
+	.mock-table-row {
+		display: flex;
+		position: relative;
+		border-bottom: 1px solid #1e2433;
+	}
+
+	.mock-table-row:last-child {
+		border-bottom: none;
+	}
+
+	.mock-table-cell {
+		flex: 1;
+		padding: 10px 12px;
+	}
+
+	.mock-table-cell-bar {
+		height: 4px;
+		background: #2d3548;
+		border-radius: 2px;
+		width: 60%;
+	}
+
+	.mock-table-arrow {
+		position: absolute;
+		right: 12px;
+		top: 50%;
+		transform: translateY(-50%);
+		font-size: 16px;
+		color: #475569;
+	}
+
+	/* Navigation Badge */
+	.mock-nav-badge {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		background: rgba(20, 184, 166, 0.15);
+		color: #14b8a6;
+		font-size: 10px;
+		font-weight: 500;
+		padding: 3px 8px;
+		border-radius: 4px;
+		font-family: ui-monospace, monospace;
+		white-space: nowrap;
+		max-width: 120px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.mock-nav-badge.small {
+		font-size: 9px;
+		padding: 2px 6px;
+	}
+
+	/* Responsive */
+	@media (max-width: 600px) {
+		.mock-section-content.layout-horizontal {
+			flex-direction: column;
+		}
+
+		.mock-nav-badge {
+			display: none;
+		}
+
+		.layout-horizontal .mock-element {
+			min-width: 100%;
+		}
+	}
+</style>

--- a/packages/ui/src/pages/graph.astro
+++ b/packages/ui/src/pages/graph.astro
@@ -4,19 +4,26 @@ import { loadScreens } from "@/utils/loadScreens"
 
 const screens = loadScreens()
 
+// Track screens with mocks for legend
+const screensWithMock = screens.filter(s => s.mock)
+const hasMocks = screensWithMock.length > 0
+
 // Generate Navigation Mermaid graph
 let navigationGraph = ""
 if (screens.length > 0) {
 	const lines: string[] = ["flowchart TD"]
 
+	// Add nodes with mock indicator
 	for (const screen of screens) {
 		const label = screen.title.replace(/"/g, "'")
 		const id = screen.id.replace(/\./g, "_")
-		lines.push(`    ${id}["${label}"]`)
+		const mockIndicator = screen.mock ? " 📱" : ""
+		lines.push(`    ${id}["${label}${mockIndicator}"]`)
 	}
 
 	lines.push("")
 
+	// Add edges
 	for (const screen of screens) {
 		if (screen.next) {
 			const fromId = screen.id.replace(/\./g, "_")
@@ -24,6 +31,25 @@ if (screens.length > 0) {
 				const toId = nextId.replace(/\./g, "_")
 				lines.push(`    ${fromId} --> ${toId}`)
 			}
+		}
+	}
+
+	// Add click handlers for screens with mocks
+	if (hasMocks) {
+		lines.push("")
+		lines.push("    %% Click handlers for screens with mocks")
+		for (const screen of screensWithMock) {
+			const id = screen.id.replace(/\./g, "_")
+			lines.push(`    click ${id} "/screen/${screen.id}"`)
+		}
+
+		// Add styling for screens with mocks
+		lines.push("")
+		lines.push("    %% Styling for screens with mocks")
+		lines.push(`    classDef hasMock stroke:#14b8a6,stroke-width:2px`)
+		for (const screen of screensWithMock) {
+			const id = screen.id.replace(/\./g, "_")
+			lines.push(`    class ${id} hasMock`)
 		}
 	}
 
@@ -161,6 +187,12 @@ const apiCount = new Set(
 						<div class="legend-node"></div>
 						<span>Screen</span>
 					</div>
+					{hasMocks && (
+						<div class="graph-legend-item">
+							<div class="legend-node legend-mock"></div>
+							<span>Screen with wireframe</span>
+						</div>
+					)}
 					<div class="graph-legend-item">
 						<div class="legend-edge"></div>
 						<span>Navigation flow</span>
@@ -330,5 +362,10 @@ const apiCount = new Set(
 	.legend-api {
 		background: #14b8a6 !important;
 		border-color: #5eead4 !important;
+	}
+
+	.legend-mock {
+		border-color: #14b8a6 !important;
+		border-width: 2px !important;
 	}
 </style>

--- a/packages/ui/src/pages/screen/[id].astro
+++ b/packages/ui/src/pages/screen/[id].astro
@@ -1,5 +1,6 @@
 ---
 import Layout from "@/layouts/Layout.astro"
+import MockPreview from "@/components/MockPreview.astro"
 import { loadScreens } from "@/utils/loadScreens"
 import { getApiDependencyCount } from "@/utils/impactAnalysis"
 
@@ -80,6 +81,21 @@ const nextScreens = screens.filter((s) => screen.next?.includes(s.id))
 						)}
 					</div>
 				</div>
+
+				<!-- Mock Wireframe -->
+				{screen.mock && (
+					<div class="section">
+						<h2 class="section-title">
+							<span class="section-title-content">
+								<svg aria-hidden="true" class="section-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+									<path stroke-linecap="round" stroke-linejoin="round" d="M10.5 1.5H8.25A2.25 2.25 0 006 3.75v16.5a2.25 2.25 0 002.25 2.25h7.5A2.25 2.25 0 0018 20.25V3.75a2.25 2.25 0 00-2.25-2.25H13.5m-3 0V3h3V1.5m-3 0h3m-3 18.75h3" />
+								</svg>
+								Wireframe Preview
+							</span>
+						</h2>
+						<MockPreview mock={screen.mock} title={screen.title} />
+					</div>
+				)}
 
 				<!-- Dependencies -->
 				{screen.dependsOn && screen.dependsOn.length > 0 && (

--- a/packages/ui/src/styles/global.css
+++ b/packages/ui/src/styles/global.css
@@ -399,6 +399,17 @@ code {
 	border-bottom: 1px solid var(--color-border);
 }
 
+.section-title-content {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.section-icon {
+	width: 16px;
+	height: 16px;
+}
+
 /* Detail Page */
 .detail-header {
 	padding: 32px 0;


### PR DESCRIPTION
## Summary

- Add wireframe-level mock definitions to `defineScreen()` for PM/designers to share screen flows with developers
- Auto-derive navigation (`next`) from mock's `navigateTo` properties
- Display mock wireframe preview in screen detail page and indicators in graph view

## Features

### Core (`@screenbook/core`)
- **Mock types**: `MockElement`, `MockSection`, `ScreenMock`, `MockLayout`
- **7 element types**: button, input, link, text, image, list, table
- **Zod schemas** with discriminated union validation
- **`extractNavigationTargets()`** helper function
- **Auto-sync**: `navigateTo` → `next` field derivation

### UI (`@screenbook/ui`)
- **MockPreview.astro** component with device-frame styling
- **Screen detail page** shows "Wireframe Preview" section
- **Navigation badges** (→ target) on buttons/links
- **Graph page** shows 📱 emoji and teal border for screens with mocks

## Screenshots

The wireframe preview displays:
- Device frame with teal header
- Section cards with teal-accented headers
- Buttons (primary/secondary/danger variants)
- Input fields with labels and placeholders
- Image placeholders with dashed borders
- Lists and tables with placeholder bars
- Navigation indicators showing destination screens

## Usage

```typescript
import { defineScreen } from "@screenbook/core"

export const screen = defineScreen({
  id: "settings",
  title: "Settings",
  route: "/settings",
  owner: ["platform"],
  
  mock: {
    sections: [
      {
        title: "Profile",
        elements: [
          { type: "input", label: "Name", placeholder: "Enter your name" },
          { type: "input", label: "Email", inputType: "email" },
          { type: "image", label: "Avatar", aspectRatio: "1:1" },
        ],
      },
      {
        title: "Actions",
        layout: "horizontal",
        elements: [
          { type: "button", label: "Save", variant: "primary" },
          { type: "button", label: "Delete", variant: "danger" },
        ],
      },
    ],
  },
})
```

## Test plan

- [x] All 182 tests pass (42 core + 140 CLI)
- [x] TypeDoc build succeeds
- [x] Wireframe preview renders correctly in UI
- [x] Graph indicators show for screens with mocks
- [x] Navigation auto-sync works correctly