### PR TITLE
docs: add mock wireframe documentation

### DIFF
--- a/docs/src/content/docs/guides/define-screen.mdx
+++ b/docs/src/content/docs/guides/define-screen.mdx
@@ -38,6 +38,7 @@ export const screen = defineScreen({
 | `next` | `string[]` | Screen IDs this screen can navigate to |
 | `description` | `string` | Optional description |
 | `links` | `Link[]` | External resource links |
+| `mock` | `ScreenMock` | Wireframe-level UI mock definition |
 
 ## Complete Example
 
@@ -162,6 +163,120 @@ npx screenbook build
 npx screenbook build --strict
 ```
 
+## Mock Wireframes
+
+The `mock` field allows you to define wireframe-level UI mockups for screen flow documentation. Navigation targets defined in mocks are automatically extracted and merged into the `next` array.
+
+### Basic Mock Structure
+
+```ts
+import { defineScreen } from "@screenbook/core"
+
+export const screen = defineScreen({
+  id: "billing.invoice.detail",
+  title: "Invoice Detail",
+  route: "/billing/invoices/:id",
+  mock: {
+    sections: [
+      {
+        title: "Header",
+        layout: "horizontal",
+        elements: [
+          { type: "text", label: "Invoice #123", variant: "heading" },
+          { type: "button", label: "Edit", navigateTo: "billing.invoice.edit" },
+        ],
+      },
+      {
+        title: "Line Items",
+        elements: [
+          { type: "list", label: "Items", itemCount: 5, itemNavigateTo: "billing.lineitem.detail" },
+        ],
+      },
+    ],
+  },
+})
+```
+
+### Element Types
+
+| Type | Properties | Description |
+|------|------------|-------------|
+| `button` | `label`, `variant?`, `navigateTo?` | Clickable button |
+| `input` | `label`, `placeholder?`, `inputType?` | Form input field |
+| `link` | `label`, `navigateTo?` | Text link |
+| `text` | `label`, `variant?` | Static text |
+| `image` | `label`, `aspectRatio?` | Image placeholder |
+| `list` | `label`, `itemCount?`, `itemNavigateTo?` | List of items |
+| `table` | `label`, `columns?`, `rowCount?`, `rowNavigateTo?` | Data table |
+
+### Button Variants
+
+```ts
+{ type: "button", label: "Submit", variant: "primary" }
+{ type: "button", label: "Cancel", variant: "secondary" }
+{ type: "button", label: "Delete", variant: "danger" }
+```
+
+### Text Variants
+
+```ts
+{ type: "text", label: "Page Title", variant: "heading" }
+{ type: "text", label: "Section Title", variant: "subheading" }
+{ type: "text", label: "Normal text", variant: "body" }
+{ type: "text", label: "Small text", variant: "caption" }
+```
+
+### Input Types
+
+```ts
+{ type: "input", label: "Email", inputType: "email" }
+{ type: "input", label: "Password", inputType: "password" }
+{ type: "input", label: "Search", inputType: "search" }
+{ type: "input", label: "Description", inputType: "textarea" }
+```
+
+### Section Layouts
+
+```ts
+// Vertical layout (default)
+{ title: "Form", layout: "vertical", elements: [...] }
+
+// Horizontal layout
+{ title: "Actions", layout: "horizontal", elements: [...] }
+```
+
+### Nested Sections
+
+Sections can contain child sections for complex layouts:
+
+```ts
+{
+  title: "Parent Section",
+  elements: [{ type: "text", label: "Parent content" }],
+  children: [
+    {
+      title: "Child Section",
+      elements: [{ type: "button", label: "Child action" }],
+    },
+  ],
+}
+```
+
+### Auto-Generated Navigation
+
+Navigation targets from mock elements are automatically merged into `next`:
+
+```ts
+// These navigateTo values...
+{ type: "button", label: "Edit", navigateTo: "billing.invoice.edit" }
+{ type: "list", label: "Items", itemNavigateTo: "billing.lineitem.detail" }
+{ type: "table", label: "Invoices", rowNavigateTo: "billing.invoice.detail" }
+
+// ...are automatically added to the screen's `next` array
+```
+
+This means you don't need to manually maintain `next` when using mocks - navigation is derived from the UI definition.
+
 ## Best Practices
 
 1. **Keep metadata close to routes** - Place `screen.meta.ts` in the same directory as your page component
@@ -171,3 +286,5 @@ npx screenbook build --strict
 3. **Track real dependencies** - Only list APIs actually called by the screen
 
 4. **Update on changes** - Keep navigation relationships in sync with actual links
+
+5. **Use mocks for documentation** - Define wireframes to visualize screen structure and auto-generate navigation

--- a/docs/src/content/docs/guides/mock-editor.mdx
+++ b/docs/src/content/docs/guides/mock-editor.mdx
@@ -1,0 +1,230 @@
+---
+title: Mock Editor
+description: Create wireframe-level UI mocks visually
+---
+
+The Mock Editor provides a visual interface for creating wireframe-level UI mocks without writing code. Access it from the screen detail page or directly at `/editor`.
+
+## Getting Started
+
+### From Screen Detail
+
+1. Navigate to a screen in Screenbook UI
+2. Click "Edit Mock" button
+3. The Mock Editor opens with the screen's existing mock (if any)
+
+### Standalone Editor
+
+Access the editor directly at:
+
+```
+http://localhost:4321/editor
+```
+
+This is useful for creating new mocks before adding them to screen definitions.
+
+## Editor Layout
+
+The Mock Editor has two panels:
+
+- **Left Panel**: Form editor for adding/editing sections and elements
+- **Right Panel**: Live preview of the mock
+
+## Working with Sections
+
+### Add a Section
+
+Click the **"+ Add Section"** button at the bottom of the form editor.
+
+### Configure Section
+
+Each section has:
+
+| Field | Options | Description |
+|-------|---------|-------------|
+| Title | Text input | Section header text |
+| Layout | Vertical, Horizontal, Grid | How elements are arranged |
+
+### Add Child Section
+
+Click **"+ Add Child Section"** within any section to create nested sections. Child sections are indicated by:
+
+- Indentation with teal left border
+- Depth indicator (L1, L2, etc.)
+
+### Remove Section
+
+Click the red **×** button in the section header.
+
+## Adding Elements
+
+Click any element button to add it to the section:
+
+| Button | Element Type |
+|--------|--------------|
+| + Button | Clickable button |
+| + Input | Form input field |
+| + Link | Text link |
+| + Text | Static text/heading |
+| + Image | Image placeholder |
+| + List | List of items |
+| + Table | Data table |
+
+## Element Configuration
+
+### Button
+
+| Field | Options |
+|-------|---------|
+| Label | Button text |
+| Variant | Primary, Secondary, Danger |
+| Navigate To | Target screen ID |
+
+### Input
+
+| Field | Options |
+|-------|---------|
+| Label | Field label |
+| Input Type | Text, Email, Password, Textarea, Search |
+| Placeholder | Placeholder text |
+
+### Link
+
+| Field | Options |
+|-------|---------|
+| Label | Link text |
+| Navigate To | Target screen ID |
+
+### Text
+
+| Field | Options |
+|-------|---------|
+| Label | Text content |
+| Variant | Heading, Subheading, Body, Caption |
+
+### Image
+
+| Field | Options |
+|-------|---------|
+| Label | Alt text/description |
+| Aspect Ratio | 16:9, 4:3, 1:1, 3:4 |
+
+### List
+
+| Field | Options |
+|-------|---------|
+| Label | List title |
+| Item Count | Number of items (1-10) |
+| Item Navigate To | Screen to navigate when clicking an item |
+
+### Table
+
+| Field | Options |
+|-------|---------|
+| Label | Table title |
+| Columns | Comma-separated column names |
+| Row Count | Number of rows (1-10) |
+| Row Navigate To | Screen to navigate when clicking a row |
+
+## Saving Your Work
+
+### Copy Code
+
+Click **"Copy Code"** to copy the mock definition to clipboard. Paste it into your `screen.meta.ts`:
+
+```ts
+export const screen = defineScreen({
+  id: "billing.invoice.detail",
+  title: "Invoice Detail",
+  route: "/billing/invoices/:id",
+  mock: {
+    sections: [
+      // ... pasted content
+    ],
+  },
+})
+```
+
+### Save to File
+
+When editing from a screen detail page:
+
+1. Click **"Save to File"**
+2. The mock is saved directly to the screen's `screen.meta.ts` file
+3. Changes are reflected immediately
+
+## Live Preview
+
+The right panel shows a real-time preview of your mock:
+
+- Section titles appear as headers
+- Elements render with appropriate styling
+- Navigation targets are displayed
+- Nested sections show with visual hierarchy
+
+## Navigation Targets
+
+When you set `navigateTo`, `itemNavigateTo`, or `rowNavigateTo`:
+
+1. The navigation target is shown in the preview
+2. Targets are automatically extracted when building
+3. Screen's `next` array is updated automatically
+
+This means defining navigation in mocks keeps your navigation graph up-to-date without manual maintenance.
+
+## Tips & Best Practices
+
+### 1. Start with Sections
+
+Organize your screen into logical sections before adding elements:
+
+```
+Header (horizontal)
+├── Title
+├── Edit Button
+└── Delete Button
+
+Main Content (vertical)
+├── Info Card
+└── Details List
+
+Actions (horizontal)
+├── Cancel Link
+└── Save Button
+```
+
+### 2. Use Horizontal Layout for Actions
+
+```ts
+{
+  title: "Actions",
+  layout: "horizontal",
+  elements: [
+    { type: "link", label: "Cancel", navigateTo: "billing.invoice.list" },
+    { type: "button", label: "Save", variant: "primary" },
+  ],
+}
+```
+
+### 3. Set Navigation Early
+
+Define `navigateTo` on buttons and links to automatically generate the navigation graph.
+
+### 4. Use Child Sections for Complex Layouts
+
+For cards or grouped content, use child sections:
+
+```ts
+{
+  title: "Invoice",
+  elements: [],
+  children: [
+    { title: "Details", elements: [...] },
+    { title: "Line Items", elements: [...] },
+  ],
+}
+```
+
+### 5. Preview Often
+
+The live preview updates instantly. Use it to verify your layout before saving.


### PR DESCRIPTION
## Summary

- Update `define-screen.mdx` with mock field documentation:
  - Add `mock` to optional fields table
  - Add "Mock Wireframes" section covering:
    - Basic mock structure
    - All 7 element types with properties
    - Button, Text, and Input variants
    - Section layouts (vertical/horizontal)
    - Nested sections
    - Auto-generated navigation from mock
  - Add best practice: "Use mocks for documentation"

- Create new `mock-editor.mdx` guide:
  - Getting started (from screen detail / standalone)
  - Editor layout overview
  - Working with sections and child sections
  - Adding and configuring all element types
  - Saving (Copy Code / Save to File)
  - Live preview features
  - Navigation targets and auto-extraction
  - Tips and best practices

## Test plan

- [x] Docs build passes
- [x] 42 pages indexed successfully