### PR TITLE
feat(ui): refresh Mock Editor design with Blueprint aesthetic

### DIFF
--- a/packages/ui/src/components/MockFormEditor.tsx
+++ b/packages/ui/src/components/MockFormEditor.tsx
@@ -481,10 +481,7 @@ export function MockFormEditor({
 			</a>
 
 			{/* Left Sidebar - Section Navigation */}
-			<nav
-				className="mock-editor__sidebar"
-				aria-label="Section navigation"
-			>
+			<nav className="mock-editor__sidebar" aria-label="Section navigation">
 				<div className="mock-editor__sidebar-header">
 					<span className="mock-editor__title">Mock Editor</span>
 					{screenId && (
@@ -496,7 +493,10 @@ export function MockFormEditor({
 				</div>
 
 				<div className="mock-editor__sidebar-content">
-					<h2 id={`${uniqueId}-sections-label`} className="mock-editor__sections-label">
+					<h2
+						id={`${uniqueId}-sections-label`}
+						className="mock-editor__sections-label"
+					>
 						SECTIONS
 					</h2>
 					<div
@@ -527,11 +527,15 @@ export function MockFormEditor({
 										{section.title || "Untitled"}
 									</span>
 									<span className="mock-editor__tab-count">
-										{section.elements.length} element{section.elements.length !== 1 ? "s" : ""}
+										{section.elements.length} element
+										{section.elements.length !== 1 ? "s" : ""}
 									</span>
 								</span>
 								{activeSection === index && (
-									<span className="mock-editor__tab-indicator" aria-hidden="true" />
+									<span
+										className="mock-editor__tab-indicator"
+										aria-hidden="true"
+									/>
 								)}
 							</button>
 						))}
@@ -548,23 +552,34 @@ export function MockFormEditor({
 			</nav>
 
 			{/* Center Panel - Editor */}
-			<section id="main-editor" className="mock-editor__main" aria-label="Section editor">
+			<section
+				id="main-editor"
+				className="mock-editor__main"
+				aria-label="Section editor"
+			>
 				{/* Editor Header */}
 				<header className="mock-editor__header">
 					<div className="mock-editor__header-left">
 						<label className="mock-editor__field-label">
-							<span className="mock-editor__field-label-text">Section title</span>
+							<span className="mock-editor__field-label-text">
+								Section title
+							</span>
 							<input
 								type="text"
 								value={currentSection?.title || ""}
 								onChange={(e) =>
-									updateSectionByPath([activeSection], { title: e.target.value })
+									updateSectionByPath([activeSection], {
+										title: e.target.value,
+									})
 								}
 								placeholder="Section title"
 								className="mock-editor__section-input"
 								aria-describedby={`${uniqueId}-title-hint`}
 							/>
-							<span id={`${uniqueId}-title-hint`} className="mock-editor__sr-only">
+							<span
+								id={`${uniqueId}-title-hint`}
+								className="mock-editor__sr-only"
+							>
 								Edit the section title
 							</span>
 						</label>
@@ -598,7 +613,10 @@ export function MockFormEditor({
 					</div>
 
 					<div className="mock-editor__header-right">
-						<label className="mock-editor__sr-only" htmlFor={`${uniqueId}-template`}>
+						<label
+							className="mock-editor__sr-only"
+							htmlFor={`${uniqueId}-template`}
+						>
 							Select template
 						</label>
 						<select
@@ -623,14 +641,17 @@ export function MockFormEditor({
 						</select>
 
 						{saveStatus === "error" && (
-							<span className="mock-editor__status mock-editor__status--error" role="alert">
+							<span
+								className="mock-editor__status mock-editor__status--error"
+								role="alert"
+							>
 								{saveError}
 							</span>
 						)}
 						{saveStatus === "saved" && (
-							<span className="mock-editor__status mock-editor__status--success" role="status">
+							<output className="mock-editor__status mock-editor__status--success">
 								Saved!
-							</span>
+							</output>
 						)}
 
 						<button
@@ -657,7 +678,6 @@ export function MockFormEditor({
 					id={`${uniqueId}-panel-${activeSection}`}
 					role="tabpanel"
 					aria-labelledby={`${uniqueId}-tab-${activeSection}`}
-					tabIndex={0}
 					className="mock-editor__editor-content"
 				>
 					{currentSection && (
@@ -673,7 +693,11 @@ export function MockFormEditor({
 										key={elementIndex}
 										element={element}
 										onChange={(updates) =>
-											updateElementByPath([activeSection], elementIndex, updates)
+											updateElementByPath(
+												[activeSection],
+												elementIndex,
+												updates,
+											)
 										}
 										onRemove={() =>
 											removeElementByPath([activeSection], elementIndex)
@@ -689,40 +713,45 @@ export function MockFormEditor({
 							</div>
 
 							{/* Add Element Buttons */}
-							<div className="mock-editor__element-buttons" role="group" aria-label="Add element">
+							<fieldset className="mock-editor__element-buttons">
+								<legend className="mock-editor__sr-only">Add element</legend>
 								{ELEMENT_TYPES.map((type) => (
 									<button
 										key={type.value}
 										type="button"
-										onClick={() => addElementByPath([activeSection], type.value)}
+										onClick={() =>
+											addElementByPath([activeSection], type.value)
+										}
 										className={`mock-editor__add-element-btn mock-editor__add-element-btn--${type.value}`}
-										aria-label={`Add ${type.label} element`}
 									>
 										+ {type.label}
 									</button>
 								))}
-							</div>
+							</fieldset>
 
 							{/* Child Sections */}
-							{currentSection.children && currentSection.children.length > 0 && (
-								<div className="mock-editor__children">
-									<h3 className="mock-editor__children-title">Child Sections</h3>
-									{currentSection.children.map((childSection, childIndex) => (
-										<SectionEditor
-											key={childIndex}
-											section={childSection}
-											path={[activeSection, childIndex]}
-											depth={1}
-											onUpdate={updateSectionByPath}
-											onRemove={removeSectionByPath}
-											onAddChild={addChildSection}
-											onAddElement={addElementByPath}
-											onRemoveElement={removeElementByPath}
-											onUpdateElement={updateElementByPath}
-										/>
-									))}
-								</div>
-							)}
+							{currentSection.children &&
+								currentSection.children.length > 0 && (
+									<div className="mock-editor__children">
+										<h3 className="mock-editor__children-title">
+											Child Sections
+										</h3>
+										{currentSection.children.map((childSection, childIndex) => (
+											<SectionEditor
+												key={childIndex}
+												section={childSection}
+												path={[activeSection, childIndex]}
+												depth={1}
+												onUpdate={updateSectionByPath}
+												onRemove={removeSectionByPath}
+												onAddChild={addChildSection}
+												onAddElement={addElementByPath}
+												onRemoveElement={removeElementByPath}
+												onUpdateElement={updateElementByPath}
+											/>
+										))}
+									</div>
+								)}
 
 							<button
 								type="button"

--- a/packages/ui/src/styles/mock-editor.css
+++ b/packages/ui/src/styles/mock-editor.css
@@ -54,12 +54,12 @@
 
 /* Reduced motion support */
 @media (prefers-reduced-motion: reduce) {
+	.mock-editor,
 	.mock-editor *,
 	.mock-editor *::before,
 	.mock-editor *::after {
-		animation-duration: 0.01ms !important;
-		animation-iteration-count: 1 !important;
-		transition-duration: 0.01ms !important;
+		animation: none;
+		transition: none;
 	}
 }
 
@@ -337,7 +337,11 @@
 	flex-direction: column;
 	position: relative;
 	z-index: 1;
-	background: linear-gradient(180deg, var(--me-bg-panel) 0%, var(--me-bg-deep) 100%);
+	background: linear-gradient(
+		180deg,
+		var(--me-bg-panel) 0%,
+		var(--me-bg-deep) 100%
+	);
 }
 
 /* Editor Header */
@@ -595,13 +599,27 @@
 }
 
 /* Element color variations */
-.mock-editor__element--button { border-left: 3px solid var(--me-color-button); }
-.mock-editor__element--input { border-left: 3px solid var(--me-color-input); }
-.mock-editor__element--link { border-left: 3px solid var(--me-color-link); }
-.mock-editor__element--text { border-left: 3px solid var(--me-color-text); }
-.mock-editor__element--image { border-left: 3px solid var(--me-color-image); }
-.mock-editor__element--list { border-left: 3px solid var(--me-color-list); }
-.mock-editor__element--table { border-left: 3px solid var(--me-color-table); }
+.mock-editor__element--button {
+	border-left: 3px solid var(--me-color-button);
+}
+.mock-editor__element--input {
+	border-left: 3px solid var(--me-color-input);
+}
+.mock-editor__element--link {
+	border-left: 3px solid var(--me-color-link);
+}
+.mock-editor__element--text {
+	border-left: 3px solid var(--me-color-text);
+}
+.mock-editor__element--image {
+	border-left: 3px solid var(--me-color-image);
+}
+.mock-editor__element--list {
+	border-left: 3px solid var(--me-color-list);
+}
+.mock-editor__element--table {
+	border-left: 3px solid var(--me-color-table);
+}
 
 .mock-editor__element-header {
 	display: flex;
@@ -623,13 +641,34 @@
 	background: rgba(255, 255, 255, 0.05);
 }
 
-.mock-editor__element-type--button { color: var(--me-color-button); background: rgba(45, 212, 191, 0.1); }
-.mock-editor__element-type--input { color: var(--me-color-input); background: rgba(129, 140, 248, 0.1); }
-.mock-editor__element-type--link { color: var(--me-color-link); background: rgba(167, 139, 250, 0.1); }
-.mock-editor__element-type--text { color: var(--me-color-text); background: rgba(148, 163, 184, 0.1); }
-.mock-editor__element-type--image { color: var(--me-color-image); background: rgba(251, 191, 36, 0.1); }
-.mock-editor__element-type--list { color: var(--me-color-list); background: rgba(244, 114, 182, 0.1); }
-.mock-editor__element-type--table { color: var(--me-color-table); background: rgba(34, 211, 238, 0.1); }
+.mock-editor__element-type--button {
+	color: var(--me-color-button);
+	background: rgba(45, 212, 191, 0.1);
+}
+.mock-editor__element-type--input {
+	color: var(--me-color-input);
+	background: rgba(129, 140, 248, 0.1);
+}
+.mock-editor__element-type--link {
+	color: var(--me-color-link);
+	background: rgba(167, 139, 250, 0.1);
+}
+.mock-editor__element-type--text {
+	color: var(--me-color-text);
+	background: rgba(148, 163, 184, 0.1);
+}
+.mock-editor__element-type--image {
+	color: var(--me-color-image);
+	background: rgba(251, 191, 36, 0.1);
+}
+.mock-editor__element-type--list {
+	color: var(--me-color-list);
+	background: rgba(244, 114, 182, 0.1);
+}
+.mock-editor__element-type--table {
+	color: var(--me-color-table);
+	background: rgba(34, 211, 238, 0.1);
+}
 
 .mock-editor__element-actions {
 	display: flex;
@@ -714,6 +753,8 @@
 	flex-wrap: wrap;
 	gap: 8px;
 	padding: 16px 0;
+	border: none;
+	margin: 0;
 }
 
 .mock-editor__add-element-btn {
@@ -741,13 +782,27 @@
 	box-shadow: var(--me-focus-ring);
 }
 
-.mock-editor__add-element-btn--button:hover { border-color: var(--me-color-button); }
-.mock-editor__add-element-btn--input:hover { border-color: var(--me-color-input); }
-.mock-editor__add-element-btn--link:hover { border-color: var(--me-color-link); }
-.mock-editor__add-element-btn--text:hover { border-color: var(--me-color-text); }
-.mock-editor__add-element-btn--image:hover { border-color: var(--me-color-image); }
-.mock-editor__add-element-btn--list:hover { border-color: var(--me-color-list); }
-.mock-editor__add-element-btn--table:hover { border-color: var(--me-color-table); }
+.mock-editor__add-element-btn--button:hover {
+	border-color: var(--me-color-button);
+}
+.mock-editor__add-element-btn--input:hover {
+	border-color: var(--me-color-input);
+}
+.mock-editor__add-element-btn--link:hover {
+	border-color: var(--me-color-link);
+}
+.mock-editor__add-element-btn--text:hover {
+	border-color: var(--me-color-text);
+}
+.mock-editor__add-element-btn--image:hover {
+	border-color: var(--me-color-image);
+}
+.mock-editor__add-element-btn--list:hover {
+	border-color: var(--me-color-list);
+}
+.mock-editor__add-element-btn--table:hover {
+	border-color: var(--me-color-table);
+}
 
 /* Children Sections */
 .mock-editor__children {
@@ -909,7 +964,8 @@
 }
 
 @keyframes pulse {
-	0%, 100% {
+	0%,
+	100% {
 		opacity: 0.4;
 		transform: scale(0.9);
 	}
@@ -1242,7 +1298,11 @@
 	content: "";
 	position: absolute;
 	inset: 0;
-	background: radial-gradient(circle at left center, var(--me-accent-glow) 0%, transparent 70%);
+	background: radial-gradient(
+		circle at left center,
+		var(--me-accent-glow) 0%,
+		transparent 70%
+	);
 	pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary

- Redesign Mock Editor with a Blueprint/Architect aesthetic
- Create dedicated CSS file with custom properties for theming
- Add grid background pattern for technical/blueprint feel
- Implement color-coded element type badges
- Add smooth hover animations and transitions  
- Increase Live Preview width (420px → 520px) for better visibility
- Add pulsing LIVE PREVIEW indicator
- Refactor component from inline styles to CSS classes

## Design Features

- **Typography**: JetBrains Mono for code/labels, DM Sans for body text
- **Color System**: Teal primary with color-coded element types
- **Animations**: Subtle hover effects and fade-in transitions
- **Grid Background**: Technical blueprint aesthetic

## Test plan

- [ ] Open Mock Editor at `/editor`
- [ ] Verify grid background pattern renders
- [ ] Test adding elements and verify color-coded badges
- [ ] Apply templates and verify preview displays correctly
- [ ] Test hover effects on buttons and element cards