### PR TITLE
chore: add changeset for v1.1.0 release

### DIFF
--- a/.changeset/unified-screenbook-package.md
+++ b/.changeset/unified-screenbook-package.md
@@ -1,0 +1,12 @@
+---
+"screenbook": minor
+"@screenbook/ui": patch
+---
+
+feat: add unified screenbook package for simplified installation
+
+- New `screenbook` umbrella package that includes core, cli, and ui
+- Simplified installation: `pnpm add -D screenbook`
+- Unified imports: `import { defineScreen } from "screenbook"`
+- Mock Editor redesign with 3-column tabbed panels layout
+- Improved accessibility (Lighthouse 100%)


### PR DESCRIPTION
## Summary

Add changeset for releasing:
- `screenbook` (new package) - minor bump to 0.1.0
- `@screenbook/ui` - patch bump for Mock Editor redesign

## Changes included in this release

- New unified `screenbook` package for simplified installation
- Mock Editor 3-column tabbed panels redesign
- Accessibility improvements (Lighthouse 100%)

## After merge

1. Release workflow will create a Release PR with version bumps
2. Merge Release PR to publish to npm