### PR TITLE
fix: skip already published package versions in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,17 +75,41 @@ jobs:
         run: npm install -g npm@latest
 
       - name: Publish @screenbook/core
-        run: npm publish --access public --provenance
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if npm view @screenbook/core@$PKG_VERSION version 2>/dev/null; then
+            echo "Version $PKG_VERSION already published, skipping"
+          else
+            npm publish --access public --provenance
+          fi
         working-directory: packages/core
 
       - name: Publish @screenbook/cli
-        run: npm publish --access public --provenance
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if npm view @screenbook/cli@$PKG_VERSION version 2>/dev/null; then
+            echo "Version $PKG_VERSION already published, skipping"
+          else
+            npm publish --access public --provenance
+          fi
         working-directory: packages/cli
 
       - name: Publish @screenbook/ui
-        run: npm publish --access public --provenance
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if npm view @screenbook/ui@$PKG_VERSION version 2>/dev/null; then
+            echo "Version $PKG_VERSION already published, skipping"
+          else
+            npm publish --access public --provenance
+          fi
         working-directory: packages/ui
 
       - name: Publish screenbook
-        run: npm publish --access public --provenance
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if npm view screenbook@$PKG_VERSION version 2>/dev/null; then
+            echo "Version $PKG_VERSION already published, skipping"
+          else
+            npm publish --access public --provenance
+          fi
         working-directory: packages/screenbook


### PR DESCRIPTION
## Summary
- Add version check before `npm publish` to prevent failures
- Each package now checks if its current version already exists on npm
- Skips publishing with a message if version is already published

## Problem
The release workflow was failing because it always tried to publish all packages, even those that hadn't changed (e.g., `@screenbook/core@1.0.0` was already published).

## Solution
Before each `npm publish`, check if the version exists:
```bash
PKG_VERSION=$(node -p "require('./package.json').version")
if npm view @screenbook/core@$PKG_VERSION version 2>/dev/null; then
  echo "Version $PKG_VERSION already published, skipping"
else
  npm publish --access public --provenance
fi
```

This allows the workflow to succeed even when some packages haven't changed between releases.