### PR TITLE
docs: simplify README, add Documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ npx screenbook dev
 
 Open http://localhost:4321 and explore your screen catalog.
 
+**For full documentation, visit [wadakatu.github.io/screenbook](https://wadakatu.github.io/screenbook).**
+
 ---
 
 ## Defining Screens

--- a/packages/screenbook/README.md
+++ b/packages/screenbook/README.md
@@ -47,6 +47,8 @@ npx screenbook dev
 
 Open http://localhost:4321 and explore your screen catalog.
 
+**For full documentation, visit [wadakatu.github.io/screenbook](https://wadakatu.github.io/screenbook).**
+
 ---
 
 ## Defining Screens


### PR DESCRIPTION
## Summary
- Remove Features section (with screenshots) from README
- Add link to Documentation site: https://wadakatu.github.io/screenbook
- Keep README focused on Quick Start and essential information

## Before
- Features section with 4 screenshots
- Long README

## After
- Documentation link at the top
- Concise README focused on getting started