### PR TITLE
chore: add Renovate configuration for automated dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,45 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": [
+		"config:recommended",
+		":semanticCommits",
+		":semanticCommitTypeAll(chore)",
+		"group:allNonMajor"
+	],
+	"labels": ["dependencies"],
+	"rangeStrategy": "bump",
+	"minimumReleaseAge": "7 days",
+	"lockFileMaintenance": {
+		"enabled": true,
+		"schedule": ["before 5am on monday"]
+	},
+	"packageRules": [
+		{
+			"description": "Auto-merge non-major devDependencies",
+			"matchDepTypes": ["devDependencies"],
+			"matchUpdateTypes": ["minor", "patch"],
+			"automerge": true
+		},
+		{
+			"description": "Group TypeScript related packages",
+			"matchPackagePatterns": ["^typescript", "^@types/"],
+			"groupName": "typescript"
+		},
+		{
+			"description": "Group Astro ecosystem",
+			"matchPackagePatterns": ["^astro", "^@astrojs/"],
+			"groupName": "astro"
+		},
+		{
+			"description": "Group Biome",
+			"matchPackagePatterns": ["^@biomejs/"],
+			"groupName": "biome"
+		},
+		{
+			"description": "Group Vitest",
+			"matchPackagePatterns": ["^vitest", "^@vitest/"],
+			"groupName": "vitest"
+		}
+	],
+	"schedule": ["after 10pm and before 5am every weekday", "every weekend"]
+}


### PR DESCRIPTION
## Summary
- Add Renovate configuration for automated dependency management

## Changes
- Create `renovate.json` with OSS-friendly settings

## Configuration Details
- **7-day wait**: `minimumReleaseAge: "7 days"` - Wait 1 week after package release before creating PR (security consideration)
- **Grouped updates**: TypeScript, Astro, Biome, Vitest packages grouped together
- **Auto-merge**: Non-major devDependencies auto-merged after CI passes
- **Schedule**: Runs during off-hours (nights/weekends) to minimize disruption
- **Lockfile maintenance**: Weekly lockfile updates on Mondays

## Next Steps
After merging, enable the Renovate GitHub App on this repository:
https://github.com/apps/renovate

Closes #59