### PR TITLE
ci: add stale issue and PR workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,50 @@
+name: Stale Issues and PRs
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Run daily at midnight UTC
+  workflow_dispatch: # Allow manual trigger
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # Issue settings
+          days-before-issue-stale: 60
+          days-before-issue-close: 7
+          stale-issue-label: "stale"
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it has not had recent activity.
+            It will be closed in 7 days if no further activity occurs.
+            If this issue is still relevant, please comment or remove the stale label.
+          close-issue-message: |
+            This issue has been automatically closed due to inactivity.
+            Feel free to reopen if this is still relevant.
+
+          # PR settings
+          days-before-pr-stale: 30
+          days-before-pr-close: 7
+          stale-pr-label: "stale"
+          stale-pr-message: |
+            This pull request has been automatically marked as stale because it has not had recent activity.
+            It will be closed in 7 days if no further activity occurs.
+            If this PR is still relevant, please comment, push changes, or remove the stale label.
+          close-pr-message: |
+            This pull request has been automatically closed due to inactivity.
+            Feel free to reopen if this is still relevant.
+
+          # Exempt labels - issues/PRs with these labels won't be marked stale
+          exempt-issue-labels: "pinned,enhancement,bug,help wanted"
+          exempt-pr-labels: "pinned,work in progress"
+
+          # Don't close issues/PRs with these labels
+          exempt-all-milestones: true
+
+          # Operations per run (to avoid rate limiting)
+          operations-per-run: 100


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow to automatically manage stale issues and PRs
- Keeps the issue tracker clean and encourages timely responses

## Configuration

| Setting | Issues | PRs |
|---------|--------|-----|
| Days before stale | 60 | 30 |
| Days before close | 7 | 7 |
| Stale label | `stale` | `stale` |

## Exempt Labels

Issues and PRs with these labels will not be marked stale:
- `pinned`
- `enhancement`
- `bug`
- `help wanted`
- `work in progress`

## Schedule

Runs daily at midnight UTC. Can also be triggered manually via workflow_dispatch.

Closes #61