### PR TITLE
ci: add CodeQL security scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,38 @@
+name: CodeQL Security Analysis
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "0 6 * * 1" # Run every Monday at 6:00 UTC
+
+permissions:
+  security-events: write
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          queries: security-extended
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:javascript-typescript"


### PR DESCRIPTION
## Summary

- Add GitHub CodeQL security scanning workflow
- Automatically detects security vulnerabilities in JavaScript/TypeScript code

## Configuration

| Setting | Value |
|---------|-------|
| Languages | JavaScript/TypeScript |
| Query suite | security-extended |
| Schedule | Weekly (Monday 6:00 UTC) |

## Triggers

- Push to `main`
- Pull requests to `main`
- Weekly scheduled scan

## Security Tab

After merging, security alerts will appear in the repository's Security tab under "Code scanning alerts".

Closes #62