### PR TITLE
ci: add automated GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
     needs: release
     if: needs.release.outputs.hasChangesets == 'false'
     permissions:
-      contents: read
+      contents: write
       id-token: write
     steps:
       - name: Checkout
@@ -114,3 +114,22 @@ jobs:
             npm publish --access public --provenance
           fi
         working-directory: packages/screenbook
+
+      - name: Get version for release
+        id: version
+        run: echo "version=$(node -p "require('./packages/screenbook/package.json').version")" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="v${{ steps.version.outputs.version }}"
+          # Check if release already exists
+          if gh release view "$VERSION" > /dev/null 2>&1; then
+            echo "Release $VERSION already exists, skipping"
+          else
+            gh release create "$VERSION" \
+              --title "$VERSION" \
+              --generate-notes \
+              --latest
+          fi


### PR DESCRIPTION
## Summary

- Add GitHub Release creation after npm publish
- Uses `gh release create` with `--generate-notes` for automatic changelog

## How It Works

1. Changesets action creates version bump PRs
2. When merged, npm packages are published
3. After publish, a GitHub Release is created with auto-generated notes

## Changes

- Add `contents: write` permission to publish job
- Add steps to get version and create release
- Skip if release already exists (idempotent)

Closes #64