### PR TITLE
fix(cli): recognize unified screenbook package in doctor command

### DIFF
--- a/packages/cli/src/__tests__/doctor.test.ts
+++ b/packages/cli/src/__tests__/doctor.test.ts
@@ -124,6 +124,38 @@ describe("doctor checks", () => {
 			expect(result.message).toContain("@screenbook/core not found")
 		})
 
+		it("should pass when unified screenbook package is installed", async () => {
+			writeFileSync(
+				join(testDir, "package.json"),
+				JSON.stringify({
+					devDependencies: {
+						screenbook: "^1.0.0",
+					},
+				}),
+			)
+
+			const result = await checkDependencies(testDir)
+
+			expect(result.status).toBe("pass")
+			expect(result.message).toContain("screenbook@^1.0.0")
+		})
+
+		it("should pass when unified screenbook package is in dependencies", async () => {
+			writeFileSync(
+				join(testDir, "package.json"),
+				JSON.stringify({
+					dependencies: {
+						screenbook: "workspace:*",
+					},
+				}),
+			)
+
+			const result = await checkDependencies(testDir)
+
+			expect(result.status).toBe("pass")
+			expect(result.message).toContain("screenbook@workspace:*")
+		})
+
 		it("should fail when package.json is invalid JSON", async () => {
 			writeFileSync(join(testDir, "package.json"), "not valid json")
 
@@ -348,6 +380,22 @@ describe("doctor checks", () => {
 			const result = await checkVersionCompatibility(testDir)
 
 			expect(result.status).toBe("pass")
+		})
+
+		it("should pass when unified screenbook package is installed", async () => {
+			writeFileSync(
+				join(testDir, "package.json"),
+				JSON.stringify({
+					devDependencies: {
+						screenbook: "^1.0.0",
+					},
+				}),
+			)
+
+			const result = await checkVersionCompatibility(testDir)
+
+			expect(result.status).toBe("pass")
+			expect(result.message).toContain("unified screenbook package")
 		})
 	})
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -103,8 +103,18 @@ export async function checkDependencies(cwd: string): Promise<CheckResult> {
 		const pkg = JSON.parse(content) as PackageJson
 
 		const allDeps = { ...pkg.dependencies, ...pkg.devDependencies }
+		const unifiedVersion = allDeps.screenbook
 		const coreVersion = allDeps["@screenbook/core"]
 		const cliVersion = allDeps["@screenbook/cli"]
+
+		// Check for unified screenbook package first
+		if (unifiedVersion) {
+			return {
+				name: "Dependencies",
+				status: "pass",
+				message: `screenbook@${unifiedVersion}`,
+			}
+		}
 
 		if (!coreVersion && !cliVersion) {
 			return {
@@ -112,7 +122,7 @@ export async function checkDependencies(cwd: string): Promise<CheckResult> {
 				status: "fail",
 				message: "Screenbook packages not installed",
 				suggestion:
-					"Run 'pnpm add -D @screenbook/core @screenbook/cli' to install",
+					"Run 'pnpm add -D screenbook' or 'pnpm add -D @screenbook/core @screenbook/cli' to install",
 			}
 		}
 
@@ -275,8 +285,18 @@ export async function checkVersionCompatibility(
 		const pkg = JSON.parse(content) as PackageJson
 
 		const allDeps = { ...pkg.dependencies, ...pkg.devDependencies }
+		const unifiedVersion = allDeps.screenbook
 		const coreVersion = allDeps["@screenbook/core"]
 		const cliVersion = allDeps["@screenbook/cli"]
+
+		// Unified package - no compatibility check needed
+		if (unifiedVersion) {
+			return {
+				name: "Version compatibility",
+				status: "pass",
+				message: "Using unified screenbook package",
+			}
+		}
 
 		if (!coreVersion || !cliVersion) {
 			return {


### PR DESCRIPTION
## Summary
- Updated `checkDependencies` to detect the unified `screenbook` package
- Updated `checkVersionCompatibility` to handle the unified package case
- Added tests for both functions covering the unified package scenario

## Test plan
- [x] Run `pnpm -r --filter @screenbook/cli run test` - all tests pass
- [x] Verify `screenbook doctor` in `examples/demo` - correctly shows `screenbook@workspace:*`
- [x] Existing tests for `@screenbook/core` + `@screenbook/cli` still pass

Closes #75