### PR TITLE
Version Packages

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @screenbook/cli
 
+## 1.1.3
+
+### Patch Changes
+
+- fix(cli): recognize unified screenbook package in doctor command
+
+  The doctor command now correctly detects the unified `screenbook` package in addition to `@screenbook/core` and `@screenbook/cli`.
+
 ## 1.1.2
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@screenbook/cli",
-	"version": "1.1.2",
+	"version": "1.1.3",
 	"description": "CLI for Screenbook - screen catalog and navigation graph generator",
 	"type": "module",
 	"bin": {

--- a/packages/screenbook/CHANGELOG.md
+++ b/packages/screenbook/CHANGELOG.md
@@ -1,5 +1,16 @@
 # screenbook
 
+## 1.1.3
+
+### Patch Changes
+
+- fix(cli): recognize unified screenbook package in doctor command
+
+  The doctor command now correctly detects the unified `screenbook` package in addition to `@screenbook/core` and `@screenbook/cli`.
+
+- Updated dependencies
+  - @screenbook/cli@1.1.3
+
 ## 1.1.2
 
 ### Patch Changes

--- a/packages/screenbook/package.json
+++ b/packages/screenbook/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "screenbook",
-	"version": "1.1.2",
+	"version": "1.1.3",
 	"description": "Screen catalog and navigation graph generator for frontend applications",
 	"type": "module",
 	"bin": {


### PR DESCRIPTION
## Summary
- Bump `@screenbook/cli` to v1.1.3
- Bump `screenbook` to v1.1.3

## Changes included
- fix(cli): recognize unified screenbook package in doctor command

This release fixes the bug where the `doctor` command didn't recognize the unified `screenbook` package (#75).