### PR TITLE
chore: add changeset for v1.3.0 release

### DIFF
--- a/.changeset/five-new-frameworks.md
+++ b/.changeset/five-new-frameworks.md
@@ -1,0 +1,17 @@
+---
+"@screenbook/cli": minor
+---
+
+Add support for 5 new frameworks
+
+### Config-based routing
+- **Solid Router**: Support for `@solidjs/router` with nested routes and dynamic segments
+- **Angular Router**: Support for Angular's `Routes` configuration with lazy loading
+
+### File-based routing
+- **SolidStart**: Auto-detect projects with `@solidjs/start` package and `src/routes/` directory
+- **QwikCity**: Auto-detect projects with `@builder.io/qwik-city` package and `src/routes/` directory
+- **TanStack Start**: Auto-detect projects with `@tanstack/react-start` package and `src/routes/__root.tsx`
+
+### Bug fixes
+- Fix CLI version display (was showing hardcoded 0.0.1, now reads from package.json)


### PR DESCRIPTION
# 概要

v1.2.0 以降の変更をまとめたリリース用 changeset を追加

## 変更内容

`@screenbook/cli` を **minor** バージョンアップ (1.2.0 → 1.3.0)

### Config-based routing (新規対応)
- **Solid Router**: `@solidjs/router` のネストルート、動的セグメント対応
- **Angular Router**: Angular の `Routes` 設定、遅延読み込み対応

### File-based routing (新規対応)
- **SolidStart**: `@solidjs/start` パッケージと `src/routes/` ディレクトリ検出
- **QwikCity**: `@builder.io/qwik-city` パッケージと `src/routes/` ディレクトリ検出
- **TanStack Start**: `@tanstack/react-start` パッケージと `src/routes/__root.tsx` 検出

### Bug fixes
- CLI バージョン表示修正 (0.0.1 → package.json から動的取得)

## 関連 PR

- #116 Solid Router support
- #117 Angular Router support
- #118 SolidStart support
- #119 QwikCity support
- #120 TanStack Start support