### PR TITLE
chore: add changeset for v1.4.0 release

### DIFF
--- a/.changeset/v1.4.0-release.md
+++ b/.changeset/v1.4.0-release.md
@@ -1,0 +1,21 @@
+---
+"@screenbook/cli": minor
+"@screenbook/core": patch
+---
+
+### @screenbook/cli
+
+#### New Features
+- Streamlined `init` command with automatic prompts for generate and dev server
+- New flags: `--generate`, `--no-generate`, `--dev`, `--no-dev`, `--yes/-y`, `--ci`
+
+#### Fixes  
+- Add negatable option support for `--generate` and `--dev` flags
+
+#### Improvements
+- Update package metadata for better npm discoverability
+
+### @screenbook/core
+
+#### Improvements
+- Update package metadata for better npm discoverability


### PR DESCRIPTION
## Summary

Add changeset for v1.4.0 release covering all changes since v1.3.0.

### @screenbook/cli (minor)

#### New Features
- Streamlined `init` command with automatic prompts for generate and dev server
- New flags: `--generate`, `--no-generate`, `--dev`, `--no-dev`, `--yes/-y`, `--ci`

#### Fixes  
- Add negatable option support for `--generate` and `--dev` flags

#### Improvements
- Update package metadata for better npm discoverability

### @screenbook/core (patch)

#### Improvements
- Update package metadata for better npm discoverability

## After Merge

GitHub Actions will automatically create a "Version Packages" PR to bump versions.