### PR TITLE
feat(cli): add Angular Router navigation detection

### DIFF
--- a/packages/cli/src/__tests__/navigationAnalyzer.test.ts
+++ b/packages/cli/src/__tests__/navigationAnalyzer.test.ts
@@ -647,6 +647,40 @@ class MyComponent {
 			expect(result.warnings[0]).toContain("Dynamic navigation path")
 		})
 
+		it("should warn on empty array argument", () => {
+			const content = `
+import { Router } from "@angular/router"
+
+class MyComponent {
+  goToPage() {
+    this.router.navigate([])
+  }
+}
+`
+			const result = analyzeNavigation(content, "angular")
+
+			expect(result.navigations).toHaveLength(0)
+			expect(result.warnings).toHaveLength(1)
+			expect(result.warnings[0]).toContain("empty array")
+		})
+
+		it("should warn on missing argument to navigate", () => {
+			const content = `
+import { Router } from "@angular/router"
+
+class MyComponent {
+  goToPage() {
+    this.router.navigate()
+  }
+}
+`
+			const result = analyzeNavigation(content, "angular")
+
+			expect(result.navigations).toHaveLength(0)
+			expect(result.warnings).toHaveLength(1)
+			expect(result.warnings[0]).toContain("no arguments")
+		})
+
 		it("should detect multiple navigation patterns", () => {
 			const content = `
 import { Router } from "@angular/router"

--- a/packages/cli/src/utils/navigationAnalyzer.ts
+++ b/packages/cli/src/utils/navigationAnalyzer.ts
@@ -425,11 +425,24 @@ function extractPathFromArrayArg(
 	const firstArg = node.arguments?.[0]
 
 	if (!firstArg) {
+		// No argument provided
+		const line = node.loc?.start.line ?? 0
+		warnings.push(
+			`Navigation call at line ${line} has no arguments. Add the target screen ID manually to the 'next' field in screen.meta.ts.`,
+		)
 		return null
 	}
 
 	// Array expression: ['/path', ...]
-	if (firstArg.type === "ArrayExpression" && firstArg.elements.length > 0) {
+	if (firstArg.type === "ArrayExpression") {
+		if (firstArg.elements.length === 0) {
+			// Empty array
+			const line = node.loc?.start.line ?? 0
+			warnings.push(
+				`Navigation call at line ${line} has an empty array. Add the target screen ID manually to the 'next' field in screen.meta.ts.`,
+			)
+			return null
+		}
 		const firstElement = firstArg.elements[0]
 
 		// String literal as first element


### PR DESCRIPTION
## Summary

- Add Angular Router navigation pattern detection to `screenbook generate --detect-navigation`
- Support for `router.navigate(['/path'])` and `this.router.navigate(['/path'])`
- Support for `router.navigateByUrl('/path')` and `this.router.navigateByUrl('/path')`
- New `extractPathFromArrayArg()` helper for array-based navigation (Angular style)
- Warn on dynamic paths and non-array arguments

## Test plan

- [x] Test `router.navigate(['/path'])` detection
- [x] Test `this.router.navigate(['/path'])` detection
- [x] Test `router.navigateByUrl('/path')` detection
- [x] Test `this.router.navigateByUrl('/path')` detection
- [x] Test static template literal in array
- [x] Test warning on dynamic array element
- [x] Test warning on non-array argument
- [x] Test Angular Router framework detection
- [x] All existing tests pass (487 total)
- [x] Lint and typecheck pass

## Follow-up

Created #140 for Angular Router template navigation detection (`[routerLink]`)

Closes #134