### PR TITLE
feat(cli): add Solid Router navigation detection

### DIFF
--- a/packages/cli/src/utils/navigationAnalyzer.ts
+++ b/packages/cli/src/utils/navigationAnalyzer.ts
@@ -226,7 +226,7 @@ function extractLinkNavigation(
 				// Dynamic expression - add warning with actionable guidance
 				const line = node.loc?.start.line ?? 0
 				warnings.push(
-					`Dynamic Link ${attrName} at line ${line} cannot be statically analyzed. Add the target screen ID manually to the 'next' field in screen.meta.ts.`,
+					`Dynamic ${componentName} ${attrName} at line ${line} cannot be statically analyzed. Add the target screen ID manually to the 'next' field in screen.meta.ts.`,
 				)
 			}
 		}


### PR DESCRIPTION
## Summary
- Add Solid Router navigation detection to `screenbook generate --detect-navigation`
- Detect `<A href="/path">` component from `@solidjs/router`
- Detect `navigate()` function calls from `useNavigate()`
- Add framework detection for `@solidjs/router`

## Changes
- Updated `NavigationFramework` type to include `"solid-router"`
- Updated `detectNavigationFramework()` to detect `@solidjs/router`
- Updated `extractLinkNavigation()` to detect `<A>` component
- Updated `extractCallNavigation()` to handle `navigate()` for Solid Router
- Added 11 test cases for Solid Router patterns

## Test plan
- [x] All existing tests pass (500 tests)
- [x] New Solid Router pattern tests pass
- [x] Framework detection tests pass
- [x] Lint passes

Closes #135