### PR TITLE
feat(cli): add TanStack Router navigation detection

### DIFF
--- a/packages/cli/src/__tests__/navigationAnalyzer.test.ts
+++ b/packages/cli/src/__tests__/navigationAnalyzer.test.ts
@@ -1284,6 +1284,58 @@ export function Dashboard() {
 			expect(result.warnings).toHaveLength(1)
 			expect(result.warnings[0]).toContain("Object-based navigation")
 		})
+
+		it("should warn on navigate() with non-object argument", () => {
+			const content = `
+import { useNavigate } from "@tanstack/react-router"
+
+export function Dashboard() {
+  const navigate = useNavigate()
+  const path = "/dynamic"
+  navigate(path)
+}
+`
+			const result = analyzeNavigation(content, "tanstack-router")
+
+			expect(result.navigations).toHaveLength(0)
+			expect(result.warnings).toHaveLength(1)
+			expect(result.warnings[0]).toContain("navigate()")
+			expect(result.warnings[0]).toContain("expects an object argument")
+			expect(result.warnings[0]).toContain("'to' property")
+		})
+
+		it("should warn on navigate() with no arguments", () => {
+			const content = `
+import { useNavigate } from "@tanstack/react-router"
+
+export function Dashboard() {
+  const navigate = useNavigate()
+  navigate()
+}
+`
+			const result = analyzeNavigation(content, "tanstack-router")
+
+			expect(result.navigations).toHaveLength(0)
+			expect(result.warnings).toHaveLength(1)
+			expect(result.warnings[0]).toContain("has no arguments")
+		})
+
+		it("should warn on navigate() with dynamic template literal in object", () => {
+			const content = `
+import { useNavigate } from "@tanstack/react-router"
+
+export function Dashboard() {
+  const navigate = useNavigate()
+  const userId = "123"
+  navigate({ to: \`/users/\${userId}\` })
+}
+`
+			const result = analyzeNavigation(content, "tanstack-router")
+
+			expect(result.navigations).toHaveLength(0)
+			expect(result.warnings).toHaveLength(1)
+			expect(result.warnings[0]).toContain("Object-based navigation")
+		})
 	})
 
 	describe("edge cases", () => {

--- a/packages/cli/src/utils/navigationAnalyzer.ts
+++ b/packages/cli/src/utils/navigationAnalyzer.ts
@@ -429,8 +429,16 @@ function extractPathFromCallArgs(
 }
 
 /**
- * Extract path from object argument with a specific property (e.g., `to` for TanStack Router)
- * e.g., navigate({ to: '/users' }) -> extracts '/users'
+ * Extract path from object argument with a specific property.
+ *
+ * @param node - The AST CallExpression node
+ * @param type - The navigation type to assign
+ * @param warnings - Array to collect warnings
+ * @param propertyName - The property name to look for (e.g., "to" for TanStack Router)
+ * @returns DetectedNavigation if a valid path is found, null otherwise
+ *
+ * @example
+ * // TanStack Router: navigate({ to: '/users' }) -> extracts '/users'
  */
 function extractPathFromObjectArg(
 	// biome-ignore lint/suspicious/noExplicitAny: Babel AST nodes have complex union types that are impractical to fully type
@@ -442,6 +450,10 @@ function extractPathFromObjectArg(
 	const firstArg = node.arguments?.[0]
 
 	if (!firstArg) {
+		const line = node.loc?.start.line ?? 0
+		warnings.push(
+			`Navigation call at line ${line} has no arguments. Add the target screen ID manually to the 'next' field in screen.meta.ts.`,
+		)
 		return null
 	}
 
@@ -492,7 +504,7 @@ function extractPathFromObjectArg(
 	// Non-object argument - add warning with actionable guidance
 	const line = node.loc?.start.line ?? 0
 	warnings.push(
-		`Dynamic navigation path at line ${line} cannot be statically analyzed. Add the target screen ID manually to the 'next' field in screen.meta.ts.`,
+		`navigate() at line ${line} expects an object argument with a '${propertyName}' property (e.g., navigate({ ${propertyName}: '/path' })). Add the target screen ID manually to the 'next' field in screen.meta.ts.`,
 	)
 
 	return null


### PR DESCRIPTION
## Summary

Add TanStack Router navigation detection support for `screenbook generate --detect-navigation`.

- Add `tanstack-router` to NavigationFramework type
- Detect `@tanstack/react-router` imports for framework detection
- Support `<Link to="/path">` component (same pattern as React Router)
- Support `navigate({ to: '/path' })` object-based navigation
- Add `extractPathFromObjectArg` helper function for TanStack-style navigation
- Add 20 comprehensive tests for TanStack Router patterns

## Detected Patterns

| Pattern | Example | Type |
|---------|---------|------|
| Link component | `<Link to="/users">` | `link` |
| navigate() | `navigate({ to: '/dashboard' })` | `navigate` |

## Test plan

- [x] All existing tests pass (528 tests)
- [x] New TanStack Router tests added (20 tests)
- [x] Lint passes
- [x] TypeScript type check passes

Closes #136