### PR TITLE
chore: release v1.5.0

### DIFF
--- a/examples/angular-router/CHANGELOG.md
+++ b/examples/angular-router/CHANGELOG.md
@@ -1,5 +1,12 @@
 # example-angular-router
 
+## 0.0.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @screenbook/cli@1.5.0
+
 ## 0.0.2
 
 ### Patch Changes

--- a/examples/angular-router/package.json
+++ b/examples/angular-router/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "example-angular-router",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,26 @@
 # @screenbook/cli
 
+## 1.5.0
+
+### Minor Changes
+
+- Add comprehensive navigation detection for multiple frontend frameworks
+
+  New features:
+  - **Angular template detection**: Detect `routerLink` directives in Angular component templates (both inline and external templateUrl)
+  - **Vue SFC template detection**: Detect `<RouterLink>` components in Vue Single File Components
+  - **TanStack Router support**: Detect `<Link>` components and `navigate()` calls
+  - **Solid Router support**: Detect `<A>` components and `navigate()` calls
+  - **Angular Router support**: Detect `router.navigate()` and `router.navigateByUrl()` calls
+  - **Vue Router support**: Detect `router.push()`, `router.replace()`, and object-based navigation
+  - **`--detect-navigation` flag**: Auto-detect navigation targets in components during `screenbook generate`
+  - **`--detect-api` flag**: Auto-detect API dependencies from imports during `screenbook generate`
+
+  Improvements:
+  - Extract common `ComponentAnalysisResult` type for framework analyzers
+  - Improved error handling with actionable warning messages
+  - Comprehensive test coverage for all detection patterns
+
 ## 1.4.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@screenbook/cli",
-	"version": "1.4.0",
+	"version": "1.5.0",
 	"description": "Screen catalog and navigation graph generator CLI. Auto-detect frameworks, generate docs, and analyze impact.",
 	"type": "module",
 	"bin": {

--- a/packages/screenbook/CHANGELOG.md
+++ b/packages/screenbook/CHANGELOG.md
@@ -1,5 +1,31 @@
 # screenbook
 
+## 1.5.0
+
+### Minor Changes
+
+- Add comprehensive navigation detection for multiple frontend frameworks
+
+  New features:
+  - **Angular template detection**: Detect `routerLink` directives in Angular component templates (both inline and external templateUrl)
+  - **Vue SFC template detection**: Detect `<RouterLink>` components in Vue Single File Components
+  - **TanStack Router support**: Detect `<Link>` components and `navigate()` calls
+  - **Solid Router support**: Detect `<A>` components and `navigate()` calls
+  - **Angular Router support**: Detect `router.navigate()` and `router.navigateByUrl()` calls
+  - **Vue Router support**: Detect `router.push()`, `router.replace()`, and object-based navigation
+  - **`--detect-navigation` flag**: Auto-detect navigation targets in components during `screenbook generate`
+  - **`--detect-api` flag**: Auto-detect API dependencies from imports during `screenbook generate`
+
+  Improvements:
+  - Extract common `ComponentAnalysisResult` type for framework analyzers
+  - Improved error handling with actionable warning messages
+  - Comprehensive test coverage for all detection patterns
+
+### Patch Changes
+
+- Updated dependencies
+  - @screenbook/cli@1.5.0
+
 ## 1.4.0
 
 ### Patch Changes

--- a/packages/screenbook/package.json
+++ b/packages/screenbook/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "screenbook",
-	"version": "1.4.0",
+	"version": "1.5.0",
 	"description": "Screen catalog and navigation graph generator for frontend applications",
 	"type": "module",
 	"bin": {


### PR DESCRIPTION
## Summary

Release v1.5.0 with comprehensive navigation detection features.

## Changes

### @screenbook/cli v1.5.0

#### New Features
- **Angular template detection**: Detect `routerLink` directives in Angular component templates (both inline and external templateUrl)
- **Vue SFC template detection**: Detect `<RouterLink>` components in Vue Single File Components
- **TanStack Router support**: Detect `<Link>` components and `navigate()` calls
- **Solid Router support**: Detect `<A>` components and `navigate()` calls
- **Angular Router support**: Detect `router.navigate()` and `router.navigateByUrl()` calls
- **Vue Router support**: Detect `router.push()`, `router.replace()`, and object-based navigation
- **`--detect-navigation` flag**: Auto-detect navigation targets in components during `screenbook generate`
- **`--detect-api` flag**: Auto-detect API dependencies from imports during `screenbook generate`

#### Improvements
- Extract common `ComponentAnalysisResult` type for framework analyzers
- Improved error handling with actionable warning messages
- Comprehensive test coverage for all detection patterns

### screenbook v1.5.0
Re-exports @screenbook/cli v1.5.0

## Test Plan

- [x] All tests pass (593 tests)
- [x] Build succeeds
- [x] Lint passes