### PR TITLE
fix(cli): address PR review feedback for OpenAPI integration

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,6 +37,7 @@
 	},
 	"devDependencies": {
 		"@types/prompts": "^2.4.9",
+		"openapi-types": "^12.1.3",
 		"tsdown": "catalog:"
 	},
 	"keywords": [

--- a/packages/cli/src/__tests__/dependsOnValidation.test.ts
+++ b/packages/cli/src/__tests__/dependsOnValidation.test.ts
@@ -45,8 +45,8 @@ describe("validateDependsOnReferences", () => {
 
 			expect(result.valid).toBe(false)
 			expect(result.errors).toHaveLength(1)
-			expect(result.errors[0]!.screenId).toBe("test.screen")
-			expect(result.errors[0]!.invalidApi).toBe("invalidOperationId")
+			expect(result.errors[0]?.screenId).toBe("test.screen")
+			expect(result.errors[0]?.invalidApi).toBe("invalidOperationId")
 		})
 
 		it("supports case-insensitive operationId matching", async () => {
@@ -109,7 +109,7 @@ describe("validateDependsOnReferences", () => {
 
 			expect(result.valid).toBe(false)
 			expect(result.errors).toHaveLength(1)
-			expect(result.errors[0]!.invalidApi).toBe("GET /api/nonexistent")
+			expect(result.errors[0]?.invalidApi).toBe("GET /api/nonexistent")
 		})
 	})
 
@@ -164,7 +164,7 @@ describe("validateDependsOnReferences", () => {
 
 			expect(result.valid).toBe(false)
 			expect(result.errors).toHaveLength(1)
-			expect(result.errors[0]!.suggestion).toBe("getUsers")
+			expect(result.errors[0]?.suggestion).toBe("getUsers")
 		})
 
 		it("provides suggestions for similar HTTP endpoints", async () => {
@@ -178,7 +178,7 @@ describe("validateDependsOnReferences", () => {
 
 			expect(result.valid).toBe(false)
 			expect(result.errors).toHaveLength(1)
-			expect(result.errors[0]!.suggestion).toBe("GET /api/users")
+			expect(result.errors[0]?.suggestion).toBe("GET /api/users")
 		})
 
 		it("does not provide suggestions when no close match exists", async () => {
@@ -192,7 +192,7 @@ describe("validateDependsOnReferences", () => {
 
 			expect(result.valid).toBe(false)
 			expect(result.errors).toHaveLength(1)
-			expect(result.errors[0]!.suggestion).toBeUndefined()
+			expect(result.errors[0]?.suggestion).toBeUndefined()
 		})
 	})
 

--- a/packages/cli/src/__tests__/fixtures/openapi/no-operation-id.yaml
+++ b/packages/cli/src/__tests__/fixtures/openapi/no-operation-id.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.0
+info:
+  title: No OperationId Test API
+  version: 1.0.0
+paths:
+  /api/items:
+    get:
+      summary: List all items
+      responses:
+        "200":
+          description: Success
+    post:
+      summary: Create an item
+      responses:
+        "201":
+          description: Created

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -301,7 +301,7 @@ export const lintCommand = define({
 async function lintRoutesFile(
 	routesFile: string,
 	cwd: string,
-	config: Pick<Config, "metaPattern" | "outDir" | "ignore">,
+	config: Pick<Config, "metaPattern" | "outDir" | "ignore" | "apiIntegration">,
 	adoption: AdoptionConfig,
 	allowCycles: boolean,
 	strict: boolean,
@@ -565,12 +565,10 @@ async function lintRoutesFile(
 			}
 
 			// Check dependsOn references against OpenAPI specs (if configured)
-			// Note: We need to get config from the outer scope for apiIntegration
-			const fullConfig = await loadConfig()
-			if (fullConfig.apiIntegration?.openapi?.sources?.length) {
+			if (config.apiIntegration?.openapi?.sources?.length) {
 				const openApiResult = await validateDependsOnAgainstOpenApi(
 					screens,
-					fullConfig.apiIntegration.openapi.sources,
+					config.apiIntegration.openapi.sources,
 					cwd,
 					strict,
 				)
@@ -701,69 +699,60 @@ function findOrphanScreens(screens: Screen[]): Screen[] {
  * Validate dependsOn references against OpenAPI specifications
  */
 async function validateDependsOnAgainstOpenApi(
-	screens: Screen[],
-	sources: string[],
+	screens: readonly Screen[],
+	sources: readonly string[],
 	cwd: string,
 	strict: boolean,
 ): Promise<{ hasWarnings: boolean }> {
 	let hasWarnings = false
 
-	try {
-		// Parse OpenAPI specs
-		const parseResult = await parseOpenApiSpecs(sources, cwd)
+	// Parse OpenAPI specs (errors are collected internally, not thrown)
+	const parseResult = await parseOpenApiSpecs(sources, cwd)
 
-		// Report parse errors as warnings
-		for (const error of parseResult.errors) {
-			hasWarnings = true
-			logger.blank()
-			logger.warn(`Failed to parse OpenAPI spec: ${error.source}`)
-			logger.log(`  ${logger.dim(error.message)}`)
-		}
-
-		// Skip validation if no specs were parsed successfully
-		if (parseResult.specs.length === 0) {
-			return { hasWarnings }
-		}
-
-		// Validate dependsOn references
-		const validationResult = validateDependsOnReferences(
-			screens,
-			parseResult.specs,
-		)
-
-		if (validationResult.errors.length > 0) {
-			hasWarnings = true
-			logger.blank()
-			logger.warn(
-				`Invalid API dependencies (${validationResult.errors.length}):`,
-			)
-			logger.blank()
-			logger.log(
-				"  These dependsOn references don't match any OpenAPI operation.",
-			)
-			logger.blank()
-
-			for (const error of validationResult.errors) {
-				logger.itemWarn(`${error.screenId}: "${error.invalidApi}"`)
-				if (error.suggestion) {
-					logger.log(`    ${logger.dim(`Did you mean "${error.suggestion}"?`)}`)
-				}
-			}
-
-			// Fail in strict mode
-			if (strict) {
-				logger.blank()
-				logger.errorWithHelp(
-					ERRORS.INVALID_API_DEPENDENCIES(validationResult.errors.length),
-				)
-				process.exit(1)
-			}
-		}
-	} catch (error) {
+	// Report parse errors as warnings
+	for (const error of parseResult.errors) {
 		hasWarnings = true
-		logger.warn(
-			`Failed to validate API dependencies: ${error instanceof Error ? error.message : String(error)}`,
+		logger.blank()
+		logger.warn(`Failed to parse OpenAPI spec: ${error.source}`)
+		logger.log(`  ${logger.dim(error.message)}`)
+	}
+
+	// Skip validation if no specs were parsed successfully
+	if (parseResult.specs.length === 0) {
+		return { hasWarnings }
+	}
+
+	// Validate dependsOn references
+	const validationResult = validateDependsOnReferences(
+		screens,
+		parseResult.specs,
+	)
+
+	if (validationResult.errors.length > 0) {
+		hasWarnings = true
+		logger.blank()
+		logger.warn(`Invalid API dependencies (${validationResult.errors.length}):`)
+		logger.blank()
+		logger.log(
+			"  These dependsOn references don't match any OpenAPI operation.",
 		)
+		logger.blank()
+
+		for (const error of validationResult.errors) {
+			logger.itemWarn(`${error.screenId}: "${error.invalidApi}"`)
+			if (error.suggestion) {
+				logger.log(`    ${logger.dim(`Did you mean "${error.suggestion}"?`)}`)
+			}
+		}
+
+		// Fail in strict mode
+		if (strict) {
+			logger.blank()
+			logger.errorWithHelp(
+				ERRORS.INVALID_API_DEPENDENCIES(validationResult.errors.length),
+			)
+			process.exit(1)
+		}
 	}
 
 	return { hasWarnings }

--- a/packages/cli/src/utils/openApiParser.ts
+++ b/packages/cli/src/utils/openApiParser.ts
@@ -7,13 +7,13 @@ import type { OpenAPI, OpenAPIV3 } from "openapi-types"
  */
 export interface ParsedOpenApiSpec {
 	/** Source path/URL of the OpenAPI spec */
-	source: string
+	readonly source: string
 	/** Set of valid operationIds (e.g., "getInvoiceById") */
-	operationIds: Set<string>
+	readonly operationIds: ReadonlySet<string>
 	/** Set of valid HTTP method + path combos (e.g., "GET /api/invoices/{id}") */
-	httpEndpoints: Set<string>
+	readonly httpEndpoints: ReadonlySet<string>
 	/** Map from lowercase key to original format for case-insensitive matching */
-	normalizedToOriginal: Map<string, string>
+	readonly normalizedToOriginal: ReadonlyMap<string, string>
 }
 
 /**
@@ -21,9 +21,9 @@ export interface ParsedOpenApiSpec {
  */
 export interface OpenApiParseResult {
 	/** Successfully parsed specifications */
-	specs: ParsedOpenApiSpec[]
+	readonly specs: readonly ParsedOpenApiSpec[]
 	/** Errors encountered during parsing */
-	errors: OpenApiParseError[]
+	readonly errors: readonly OpenApiParseError[]
 }
 
 /**
@@ -31,9 +31,9 @@ export interface OpenApiParseResult {
  */
 export interface OpenApiParseError {
 	/** Source path/URL that failed to parse */
-	source: string
+	readonly source: string
 	/** Error message */
-	message: string
+	readonly message: string
 }
 
 /**
@@ -157,7 +157,7 @@ async function parseOpenApiSource(
  * ```
  */
 export async function parseOpenApiSpecs(
-	sources: string[],
+	sources: readonly string[],
 	cwd: string,
 ): Promise<OpenApiParseResult> {
 	const specs: ParsedOpenApiSpec[] = []
@@ -181,7 +181,9 @@ export async function parseOpenApiSpecs(
 /**
  * Get all valid API identifiers from parsed specs (for suggestions)
  */
-export function getAllApiIdentifiers(specs: ParsedOpenApiSpec[]): string[] {
+export function getAllApiIdentifiers(
+	specs: readonly ParsedOpenApiSpec[],
+): string[] {
 	const identifiers: string[] = []
 
 	for (const spec of specs) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -410,6 +410,9 @@ importers:
       '@types/prompts':
         specifier: ^2.4.9
         version: 2.4.9
+      openapi-types:
+        specifier: ^12.1.3
+        version: 12.1.3
       tsdown:
         specifier: 'catalog:'
         version: 0.18.3(typescript@5.9.3)(vue-tsc@3.2.1(typescript@5.9.3))


### PR DESCRIPTION
## Summary

PR #151のレビューフィードバックに対応する修正です。

### Changes

#### Type Safety Improvements
- `ParsedOpenApiSpec`, `OpenApiParseResult`, `OpenApiParseError`インターフェースにreadonly修飾子を追加
- `DependsOnValidationResult`に判別可能なユニオン型を使用
- 関数シグネチャをreadonly配列を受け入れるように更新

#### Bug Fixes
- `normalizeForMatching`関数のnon-null assertionを修正
- 重複する`getAllIdentifiers`関数を削除（`openApiParser`の`getAllApiIdentifiers`を使用）
- `validateDependsOnAgainstOpenApi`の過度に広いcatchブロックを削除
- `lintRoutesFile`でconfigを再読み込みせずパラメータとして渡すように修正

#### Dependencies
- `openapi-types`を明示的なdevDependencyとして追加

#### Tests
- URL処理のテストを追加
- operationIdのない操作のテストを追加
- テストアサーションのnon-null assertionをオプショナルチェーンに修正

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes
- [x] `pnpm lint` passes (only warning is in unrelated example)