### PR TITLE
chore(release): v1.6.0

### DIFF
--- a/examples/angular-router/CHANGELOG.md
+++ b/examples/angular-router/CHANGELOG.md
@@ -1,5 +1,13 @@
 # example-angular-router
 
+## 0.0.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @screenbook/core@1.6.0
+  - @screenbook/cli@1.6.0
+
 ## 0.0.3
 
 ### Patch Changes

--- a/examples/angular-router/package.json
+++ b/examples/angular-router/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "example-angular-router",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,55 @@
 # @screenbook/cli
 
+## 1.6.0
+
+### Minor Changes
+
+- ## New Features
+
+  ### OpenAPI/Swagger Integration for dependsOn Validation
+
+  Validate `dependsOn` references against OpenAPI/Swagger specifications to catch typos and non-existent API references.
+
+  ```typescript
+  // screenbook.config.ts
+  export default defineConfig({
+    apiIntegration: {
+      openapi: {
+        sources: ["./openapi.yaml"],
+      },
+    },
+  });
+  ```
+
+  Supports both operationId and HTTP format:
+
+  ```typescript
+  dependsOn: [
+    "getInvoiceById", // operationId format
+    "GET /api/users/{id}", // HTTP format
+  ];
+  ```
+
+  ### Badge Command
+
+  New `screenbook badge` command to generate coverage badges for your README.
+
+  ### Link Type Icons
+
+  Added `type` field to `ScreenLink` for displaying icons in the navigation graph.
+
+  ### Improved Error Messages
+
+  Enhanced error messages with verbose mode and suggestions for common mistakes.
+
+  ## Bug Fixes
+  - Fixed CLI bundling issue with `@vue/compiler-sfc` packages causing startup failures
+
+### Patch Changes
+
+- Updated dependencies
+  - @screenbook/core@1.6.0
+
 ## 1.5.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@screenbook/cli",
-	"version": "1.5.0",
+	"version": "1.6.0",
 	"description": "Screen catalog and navigation graph generator CLI. Auto-detect frameworks, generate docs, and analyze impact.",
 	"type": "module",
 	"bin": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,50 @@
 # @screenbook/core
 
+## 1.6.0
+
+### Minor Changes
+
+- ## New Features
+
+  ### OpenAPI/Swagger Integration for dependsOn Validation
+
+  Validate `dependsOn` references against OpenAPI/Swagger specifications to catch typos and non-existent API references.
+
+  ```typescript
+  // screenbook.config.ts
+  export default defineConfig({
+    apiIntegration: {
+      openapi: {
+        sources: ["./openapi.yaml"],
+      },
+    },
+  });
+  ```
+
+  Supports both operationId and HTTP format:
+
+  ```typescript
+  dependsOn: [
+    "getInvoiceById", // operationId format
+    "GET /api/users/{id}", // HTTP format
+  ];
+  ```
+
+  ### Badge Command
+
+  New `screenbook badge` command to generate coverage badges for your README.
+
+  ### Link Type Icons
+
+  Added `type` field to `ScreenLink` for displaying icons in the navigation graph.
+
+  ### Improved Error Messages
+
+  Enhanced error messages with verbose mode and suggestions for common mistakes.
+
+  ## Bug Fixes
+  - Fixed CLI bundling issue with `@vue/compiler-sfc` packages causing startup failures
+
 ## 1.4.0
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@screenbook/core",
-	"version": "1.4.0",
+	"version": "1.6.0",
 	"description": "Define screens in code with TypeScript. Core library for screen catalog and navigation graph generation.",
 	"type": "module",
 	"exports": {

--- a/packages/screenbook/CHANGELOG.md
+++ b/packages/screenbook/CHANGELOG.md
@@ -1,5 +1,57 @@
 # screenbook
 
+## 1.6.0
+
+### Minor Changes
+
+- ## New Features
+
+  ### OpenAPI/Swagger Integration for dependsOn Validation
+
+  Validate `dependsOn` references against OpenAPI/Swagger specifications to catch typos and non-existent API references.
+
+  ```typescript
+  // screenbook.config.ts
+  export default defineConfig({
+    apiIntegration: {
+      openapi: {
+        sources: ["./openapi.yaml"],
+      },
+    },
+  });
+  ```
+
+  Supports both operationId and HTTP format:
+
+  ```typescript
+  dependsOn: [
+    "getInvoiceById", // operationId format
+    "GET /api/users/{id}", // HTTP format
+  ];
+  ```
+
+  ### Badge Command
+
+  New `screenbook badge` command to generate coverage badges for your README.
+
+  ### Link Type Icons
+
+  Added `type` field to `ScreenLink` for displaying icons in the navigation graph.
+
+  ### Improved Error Messages
+
+  Enhanced error messages with verbose mode and suggestions for common mistakes.
+
+  ## Bug Fixes
+  - Fixed CLI bundling issue with `@vue/compiler-sfc` packages causing startup failures
+
+### Patch Changes
+
+- Updated dependencies
+  - @screenbook/core@1.6.0
+  - @screenbook/cli@1.6.0
+  - @screenbook/ui@1.6.0
+
 ## 1.5.0
 
 ### Minor Changes

--- a/packages/screenbook/package.json
+++ b/packages/screenbook/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "screenbook",
-	"version": "1.5.0",
+	"version": "1.6.0",
 	"description": "Screen catalog and navigation graph generator for frontend applications",
 	"type": "module",
 	"bin": {

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,55 @@
 # @screenbook/ui
 
+## 1.6.0
+
+### Minor Changes
+
+- ## New Features
+
+  ### OpenAPI/Swagger Integration for dependsOn Validation
+
+  Validate `dependsOn` references against OpenAPI/Swagger specifications to catch typos and non-existent API references.
+
+  ```typescript
+  // screenbook.config.ts
+  export default defineConfig({
+  	apiIntegration: {
+  		openapi: {
+  			sources: ["./openapi.yaml"],
+  		},
+  	},
+  })
+  ```
+
+  Supports both operationId and HTTP format:
+
+  ```typescript
+  dependsOn: [
+  	"getInvoiceById", // operationId format
+  	"GET /api/users/{id}", // HTTP format
+  ]
+  ```
+
+  ### Badge Command
+
+  New `screenbook badge` command to generate coverage badges for your README.
+
+  ### Link Type Icons
+
+  Added `type` field to `ScreenLink` for displaying icons in the navigation graph.
+
+  ### Improved Error Messages
+
+  Enhanced error messages with verbose mode and suggestions for common mistakes.
+
+  ## Bug Fixes
+  - Fixed CLI bundling issue with `@vue/compiler-sfc` packages causing startup failures
+
+### Patch Changes
+
+- Updated dependencies
+  - @screenbook/core@1.6.0
+
 ## 1.4.0
 
 ### Patch Changes

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@screenbook/ui",
-	"version": "1.4.0",
+	"version": "1.6.0",
 	"description": "UI for Screenbook - screen catalog and navigation graph viewer",
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## Release v1.6.0

This PR updates package versions and CHANGELOGs for the v1.6.0 release.

### New Features

#### OpenAPI/Swagger Integration for dependsOn Validation

Validate `dependsOn` references against OpenAPI/Swagger specifications to catch typos and non-existent API references.

```typescript
// screenbook.config.ts
export default defineConfig({
  apiIntegration: {
    openapi: {
      sources: ["./openapi.yaml"],
    },
  },
})
```

Supports both operationId and HTTP format:
```typescript
dependsOn: [
  "getInvoiceById",        // operationId format
  "GET /api/users/{id}",   // HTTP format
]
```

#### Badge Command

New `screenbook badge` command to generate coverage badges for your README.

#### Link Type Icons

Added `type` field to `ScreenLink` for displaying icons in the navigation graph.

#### Improved Error Messages

Enhanced error messages with verbose mode and suggestions for common mistakes.

### Bug Fixes

- Fixed CLI bundling issue with `@vue/compiler-sfc` packages causing startup failures (#154)

### Packages

| Package | Version |
|---------|---------|
| `screenbook` | 1.6.0 |
| `@screenbook/core` | 1.6.0 |
| `@screenbook/cli` | 1.6.0 |
| `@screenbook/ui` | 1.6.0 |