### PR TITLE
fix(ci): use pnpm publish to resolve workspace:* protocol

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
           if npm view @screenbook/core@$PKG_VERSION version 2>/dev/null; then
             echo "Version $PKG_VERSION already published, skipping"
           else
-            npm publish --access public --provenance
+            pnpm publish --access public --provenance --no-git-checks
           fi
         working-directory: packages/core
 
@@ -91,7 +91,7 @@ jobs:
           if npm view @screenbook/cli@$PKG_VERSION version 2>/dev/null; then
             echo "Version $PKG_VERSION already published, skipping"
           else
-            npm publish --access public --provenance
+            pnpm publish --access public --provenance --no-git-checks
           fi
         working-directory: packages/cli
 
@@ -101,7 +101,7 @@ jobs:
           if npm view @screenbook/ui@$PKG_VERSION version 2>/dev/null; then
             echo "Version $PKG_VERSION already published, skipping"
           else
-            npm publish --access public --provenance
+            pnpm publish --access public --provenance --no-git-checks
           fi
         working-directory: packages/ui
 
@@ -111,7 +111,7 @@ jobs:
           if npm view screenbook@$PKG_VERSION version 2>/dev/null; then
             echo "Version $PKG_VERSION already published, skipping"
           else
-            npm publish --access public --provenance
+            pnpm publish --access public --provenance --no-git-checks
           fi
         working-directory: packages/screenbook
 


### PR DESCRIPTION
## Summary

- Replace `npm publish` with `pnpm publish` in the release workflow
- `pnpm publish` automatically converts `workspace:*` protocols to actual version numbers during publishing

## Problem

Installing `@screenbook/cli` (and other packages) in a pnpm workspace fails because packages were published with `workspace:*` protocol instead of actual versions:

```
ERR_PNPM_WORKSPACE_PKG_NOT_FOUND  In ../..: "@screenbook/core@workspace:*" is in the dependencies but no package named "@screenbook/core" is present in the workspace
```

## Root Cause

The release workflow was using `npm publish`, which does NOT convert `workspace:*` protocols. Only `pnpm publish` handles this conversion automatically.

## Fix

Changed all publish commands from:
```bash
npm publish --access public --provenance
```
to:
```bash
pnpm publish --access public --provenance --no-git-checks
```

The `--no-git-checks` flag is needed because pnpm validates git status by default, which can fail in CI environments.

Fixes #157