### PR TITLE
chore: add changeset for workspace protocol fix

### DIFF
--- a/.changeset/fix-workspace-protocol.md
+++ b/.changeset/fix-workspace-protocol.md
@@ -1,0 +1,9 @@
+---
+"@screenbook/cli": patch
+"@screenbook/ui": patch
+"screenbook": patch
+---
+
+fix: resolve workspace:* protocol in published packages
+
+Previously, packages were published with `workspace:*` protocol instead of actual version numbers, causing installation failures in pnpm workspaces. This release fixes the issue by using `pnpm publish` which automatically converts workspace protocols.


### PR DESCRIPTION
## Summary

Adds changeset for patch release to republish packages with correct dependency versions.

## Packages to be released

- `@screenbook/cli`: patch
- `@screenbook/ui`: patch  
- `screenbook`: patch

## Context

After merging #158, the release workflow now uses `pnpm publish` which correctly converts `workspace:*` protocols. This changeset will trigger a new release with properly resolved dependencies.

Relates to #157