### PR TITLE
Document: Update installation instructions to use screenbook package

### DIFF
--- a/docs/scripts/generate-cli-docs.ts
+++ b/docs/scripts/generate-cli-docs.ts
@@ -129,9 +129,9 @@ Screenbook provides a powerful CLI to manage your screen catalog.
 ## Installation
 
 \`\`\`bash
-npm install -g @screenbook/cli
+npm install -D screenbook
 # or
-pnpm add -g @screenbook/cli
+pnpm add -D screenbook
 \`\`\`
 
 ## Commands

--- a/docs/src/content/docs/api/functions/defineConfig.md
+++ b/docs/src/content/docs/api/functions/defineConfig.md
@@ -7,7 +7,7 @@ title: "defineConfig"
 
 > **defineConfig**(`input`): [`Config`](/screenbook/api/interfaces/config/)
 
-Defined in: [packages/core/src/defineScreen.ts:68](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/defineScreen.ts#L68)
+Defined in: [packages/core/src/defineScreen.ts:68](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/defineScreen.ts#L68)
 
 Define Screenbook configuration.
 

--- a/docs/src/content/docs/api/functions/defineScreen.md
+++ b/docs/src/content/docs/api/functions/defineScreen.md
@@ -7,7 +7,7 @@ title: "defineScreen"
 
 > **defineScreen**(`input`): [`Screen`](/screenbook/api/interfaces/screen/)
 
-Defined in: [packages/core/src/defineScreen.ts:39](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/defineScreen.ts#L39)
+Defined in: [packages/core/src/defineScreen.ts:39](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/defineScreen.ts#L39)
 
 Define a screen with metadata for the screen catalog.
 

--- a/docs/src/content/docs/api/functions/extractNavigationTargets.md
+++ b/docs/src/content/docs/api/functions/extractNavigationTargets.md
@@ -7,7 +7,7 @@ title: "extractNavigationTargets"
 
 > **extractNavigationTargets**(`mock`): `string`[]
 
-Defined in: [packages/core/src/extractNavigationTargets.ts:27](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/extractNavigationTargets.ts#L27)
+Defined in: [packages/core/src/extractNavigationTargets.ts:27](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/extractNavigationTargets.ts#L27)
 
 Extracts all navigation target screen IDs from a mock definition.
 

--- a/docs/src/content/docs/api/interfaces/AdoptionConfig.md
+++ b/docs/src/content/docs/api/interfaces/AdoptionConfig.md
@@ -5,7 +5,7 @@ prev: false
 title: "AdoptionConfig"
 ---
 
-Defined in: [packages/core/src/types.ts:402](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L402)
+Defined in: [packages/core/src/types.ts:402](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L402)
 
 Progressive adoption configuration for gradual rollout.
 
@@ -25,7 +25,7 @@ const adoption: AdoptionConfig = {
 
 > `optional` **includePatterns**: `string`[]
 
-Defined in: [packages/core/src/types.ts:418](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L418)
+Defined in: [packages/core/src/types.ts:418](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L418)
 
 Glob patterns to include for coverage checking (progressive mode only)
 
@@ -45,7 +45,7 @@ Glob patterns to include for coverage checking (progressive mode only)
 
 > `optional` **minimumCoverage**: `number`
 
-Defined in: [packages/core/src/types.ts:425](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L425)
+Defined in: [packages/core/src/types.ts:425](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L425)
 
 Minimum coverage percentage required to pass lint (0-100)
 
@@ -65,7 +65,7 @@ Minimum coverage percentage required to pass lint (0-100)
 
 > `optional` **mode**: `"full"` \| `"progressive"`
 
-Defined in: [packages/core/src/types.ts:411](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L411)
+Defined in: [packages/core/src/types.ts:411](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L411)
 
 Adoption mode for screen metadata coverage
 - `"full"`: All routes must have screen.meta.ts (default)

--- a/docs/src/content/docs/api/interfaces/ApiIntegrationConfig.md
+++ b/docs/src/content/docs/api/interfaces/ApiIntegrationConfig.md
@@ -5,7 +5,7 @@ prev: false
 title: "ApiIntegrationConfig"
 ---
 
-Defined in: [packages/core/src/types.ts:470](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L470)
+Defined in: [packages/core/src/types.ts:470](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L470)
 
 ## Properties
 
@@ -13,7 +13,7 @@ Defined in: [packages/core/src/types.ts:470](https://github.com/wadakatu/screenb
 
 > `optional` **clientPackages**: `string`[]
 
-Defined in: [packages/core/src/types.ts:477](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L477)
+Defined in: [packages/core/src/types.ts:477](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L477)
 
 Package names to scan for API client imports.
 These should match the import paths used in your code.
@@ -34,7 +34,7 @@ These should match the import paths used in your code.
 
 > `optional` **extractApiName**: (`importName`) => `string`
 
-Defined in: [packages/core/src/types.ts:485](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L485)
+Defined in: [packages/core/src/types.ts:485](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L485)
 
 Optional transform function to convert import name to dependsOn format.
 If not provided, the import name is used as-is.
@@ -65,7 +65,7 @@ If not provided, the import name is used as-is.
 
 > `optional` **openapi**: [`OpenApiConfig`](/screenbook/api/interfaces/openapiconfig/)
 
-Defined in: [packages/core/src/types.ts:493](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L493)
+Defined in: [packages/core/src/types.ts:493](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L493)
 
 OpenAPI specification configuration for validating dependsOn references.
 When configured, `screenbook lint` will validate that dependsOn values

--- a/docs/src/content/docs/api/interfaces/Config.md
+++ b/docs/src/content/docs/api/interfaces/Config.md
@@ -5,7 +5,7 @@ prev: false
 title: "Config"
 ---
 
-Defined in: [packages/core/src/types.ts:518](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L518)
+Defined in: [packages/core/src/types.ts:518](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L518)
 
 Screenbook configuration options.
 
@@ -15,7 +15,7 @@ Screenbook configuration options.
 
 > `optional` **adoption**: [`AdoptionConfig`](/screenbook/api/interfaces/adoptionconfig/)
 
-Defined in: [packages/core/src/types.ts:565](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L565)
+Defined in: [packages/core/src/types.ts:565](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L565)
 
 Progressive adoption configuration for gradual rollout
 
@@ -31,7 +31,7 @@ Progressive adoption configuration for gradual rollout
 
 > `optional` **apiIntegration**: [`ApiIntegrationConfig`](/screenbook/api/interfaces/apiintegrationconfig/)
 
-Defined in: [packages/core/src/types.ts:572](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L572)
+Defined in: [packages/core/src/types.ts:572](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L572)
 
 API integration configuration for auto-detecting dependencies
 from OpenAPI-generated clients (Orval, openapi-typescript, etc.)
@@ -48,7 +48,7 @@ from OpenAPI-generated clients (Orval, openapi-typescript, etc.)
 
 > **ignore**: `string`[]
 
-Defined in: [packages/core/src/types.ts:559](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L559)
+Defined in: [packages/core/src/types.ts:559](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L559)
 
 Patterns to ignore when scanning (glob patterns).
 Defaults to node_modules and .git directories.
@@ -59,7 +59,7 @@ Defaults to node_modules and .git directories.
 
 > **metaPattern**: `string`
 
-Defined in: [packages/core/src/types.ts:534](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L534)
+Defined in: [packages/core/src/types.ts:534](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L534)
 
 Glob pattern for screen metadata files.
 Supports colocation: place screen.meta.ts alongside your route files.
@@ -86,7 +86,7 @@ Supports colocation: place screen.meta.ts alongside your route files.
 
 > **outDir**: `string`
 
-Defined in: [packages/core/src/types.ts:525](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L525)
+Defined in: [packages/core/src/types.ts:525](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L525)
 
 Output directory for generated files
 
@@ -112,7 +112,7 @@ Output directory for generated files
 
 > `optional` **routesFile**: `string`
 
-Defined in: [packages/core/src/types.ts:553](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L553)
+Defined in: [packages/core/src/types.ts:553](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L553)
 
 Path to a router configuration file (for config-based routing).
 Use this for frameworks like Vue Router, React Router, etc.
@@ -134,7 +134,7 @@ Cannot be used together with routesPattern.
 
 > `optional` **routesPattern**: `string`
 
-Defined in: [packages/core/src/types.ts:544](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L544)
+Defined in: [packages/core/src/types.ts:544](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L544)
 
 Glob pattern for route files (for generate/lint commands).
 Use this for file-based routing frameworks (Next.js, Nuxt, Remix, etc.).

--- a/docs/src/content/docs/api/interfaces/ConfigInput.md
+++ b/docs/src/content/docs/api/interfaces/ConfigInput.md
@@ -5,7 +5,7 @@ prev: false
 title: "ConfigInput"
 ---
 
-Defined in: [packages/core/src/types.ts:587](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L587)
+Defined in: [packages/core/src/types.ts:587](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L587)
 
 Input type for defineConfig function.
 All fields with defaults are optional in input.
@@ -25,7 +25,7 @@ defineConfig({
 
 > `optional` **adoption**: [`AdoptionConfig`](/screenbook/api/interfaces/adoptionconfig/)
 
-Defined in: [packages/core/src/types.ts:627](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L627)
+Defined in: [packages/core/src/types.ts:627](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L627)
 
 Progressive adoption configuration
 
@@ -35,7 +35,7 @@ Progressive adoption configuration
 
 > `optional` **apiIntegration**: [`ApiIntegrationConfig`](/screenbook/api/interfaces/apiintegrationconfig/)
 
-Defined in: [packages/core/src/types.ts:633](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L633)
+Defined in: [packages/core/src/types.ts:633](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L633)
 
 API integration configuration for auto-detecting dependencies
 from OpenAPI-generated clients
@@ -46,7 +46,7 @@ from OpenAPI-generated clients
 
 > `optional` **ignore**: `string`[]
 
-Defined in: [packages/core/src/types.ts:622](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L622)
+Defined in: [packages/core/src/types.ts:622](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L622)
 
 Patterns to ignore when scanning.
 Defaults to node_modules and .git directories.
@@ -57,7 +57,7 @@ Defaults to node_modules and .git directories.
 
 > `optional` **metaPattern**: `string`
 
-Defined in: [packages/core/src/types.ts:600](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L600)
+Defined in: [packages/core/src/types.ts:600](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L600)
 
 Glob pattern for screen metadata files
 
@@ -79,7 +79,7 @@ Glob pattern for screen metadata files
 
 > `optional` **outDir**: `string`
 
-Defined in: [packages/core/src/types.ts:593](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L593)
+Defined in: [packages/core/src/types.ts:593](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L593)
 
 Output directory for generated files
 
@@ -101,7 +101,7 @@ Output directory for generated files
 
 > `optional` **routesFile**: `string`
 
-Defined in: [packages/core/src/types.ts:616](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L616)
+Defined in: [packages/core/src/types.ts:616](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L616)
 
 Path to a router configuration file (for config-based routing).
 Use this for frameworks like Vue Router, React Router, etc.
@@ -119,7 +119,7 @@ Cannot be used together with routesPattern.
 
 > `optional` **routesPattern**: `string`
 
-Defined in: [packages/core/src/types.ts:608](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L608)
+Defined in: [packages/core/src/types.ts:608](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L608)
 
 Glob pattern for route files (for generate/lint commands).
 Use this for file-based routing frameworks.

--- a/docs/src/content/docs/api/interfaces/MockButtonElement.md
+++ b/docs/src/content/docs/api/interfaces/MockButtonElement.md
@@ -5,7 +5,7 @@ prev: false
 title: "MockButtonElement"
 ---
 
-Defined in: [packages/core/src/types.ts:171](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L171)
+Defined in: [packages/core/src/types.ts:171](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L171)
 
 Button element with optional navigation and styling
 
@@ -19,7 +19,7 @@ Button element with optional navigation and styling
 
 > **label**: `string`
 
-Defined in: [packages/core/src/types.ts:165](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L165)
+Defined in: [packages/core/src/types.ts:165](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L165)
 
 Display label for the element
 
@@ -33,7 +33,7 @@ Display label for the element
 
 > `optional` **navigateTo**: `string`
 
-Defined in: [packages/core/src/types.ts:174](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L174)
+Defined in: [packages/core/src/types.ts:174](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L174)
 
 Screen ID to navigate to when clicked
 
@@ -43,7 +43,7 @@ Screen ID to navigate to when clicked
 
 > **type**: `"button"`
 
-Defined in: [packages/core/src/types.ts:172](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L172)
+Defined in: [packages/core/src/types.ts:172](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L172)
 
 Element type identifier
 
@@ -57,6 +57,6 @@ Element type identifier
 
 > `optional` **variant**: `"primary"` \| `"secondary"` \| `"danger"`
 
-Defined in: [packages/core/src/types.ts:176](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L176)
+Defined in: [packages/core/src/types.ts:176](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L176)
 
 Visual style variant

--- a/docs/src/content/docs/api/interfaces/MockImageElement.md
+++ b/docs/src/content/docs/api/interfaces/MockImageElement.md
@@ -5,7 +5,7 @@ prev: false
 title: "MockImageElement"
 ---
 
-Defined in: [packages/core/src/types.ts:211](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L211)
+Defined in: [packages/core/src/types.ts:211](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L211)
 
 Image placeholder element
 
@@ -19,7 +19,7 @@ Image placeholder element
 
 > `optional` **aspectRatio**: `string`
 
-Defined in: [packages/core/src/types.ts:214](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L214)
+Defined in: [packages/core/src/types.ts:214](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L214)
 
 Aspect ratio (e.g., "16:9", "1:1")
 
@@ -29,7 +29,7 @@ Aspect ratio (e.g., "16:9", "1:1")
 
 > **label**: `string`
 
-Defined in: [packages/core/src/types.ts:165](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L165)
+Defined in: [packages/core/src/types.ts:165](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L165)
 
 Display label for the element
 
@@ -43,7 +43,7 @@ Display label for the element
 
 > **type**: `"image"`
 
-Defined in: [packages/core/src/types.ts:212](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L212)
+Defined in: [packages/core/src/types.ts:212](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L212)
 
 Element type identifier
 

--- a/docs/src/content/docs/api/interfaces/MockInputElement.md
+++ b/docs/src/content/docs/api/interfaces/MockInputElement.md
@@ -5,7 +5,7 @@ prev: false
 title: "MockInputElement"
 ---
 
-Defined in: [packages/core/src/types.ts:182](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L182)
+Defined in: [packages/core/src/types.ts:182](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L182)
 
 Input field element
 
@@ -19,7 +19,7 @@ Input field element
 
 > `optional` **inputType**: `"text"` \| `"email"` \| `"password"` \| `"textarea"` \| `"search"`
 
-Defined in: [packages/core/src/types.ts:187](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L187)
+Defined in: [packages/core/src/types.ts:187](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L187)
 
 Input type for semantics
 
@@ -29,7 +29,7 @@ Input type for semantics
 
 > **label**: `string`
 
-Defined in: [packages/core/src/types.ts:165](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L165)
+Defined in: [packages/core/src/types.ts:165](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L165)
 
 Display label for the element
 
@@ -43,7 +43,7 @@ Display label for the element
 
 > `optional` **placeholder**: `string`
 
-Defined in: [packages/core/src/types.ts:185](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L185)
+Defined in: [packages/core/src/types.ts:185](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L185)
 
 Placeholder text
 
@@ -53,7 +53,7 @@ Placeholder text
 
 > **type**: `"input"`
 
-Defined in: [packages/core/src/types.ts:183](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L183)
+Defined in: [packages/core/src/types.ts:183](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L183)
 
 Element type identifier
 

--- a/docs/src/content/docs/api/interfaces/MockLinkElement.md
+++ b/docs/src/content/docs/api/interfaces/MockLinkElement.md
@@ -5,7 +5,7 @@ prev: false
 title: "MockLinkElement"
 ---
 
-Defined in: [packages/core/src/types.ts:193](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L193)
+Defined in: [packages/core/src/types.ts:193](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L193)
 
 Link element with optional navigation
 
@@ -19,7 +19,7 @@ Link element with optional navigation
 
 > **label**: `string`
 
-Defined in: [packages/core/src/types.ts:165](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L165)
+Defined in: [packages/core/src/types.ts:165](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L165)
 
 Display label for the element
 
@@ -33,7 +33,7 @@ Display label for the element
 
 > `optional` **navigateTo**: `string`
 
-Defined in: [packages/core/src/types.ts:196](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L196)
+Defined in: [packages/core/src/types.ts:196](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L196)
 
 Screen ID to navigate to when clicked
 
@@ -43,7 +43,7 @@ Screen ID to navigate to when clicked
 
 > **type**: `"link"`
 
-Defined in: [packages/core/src/types.ts:194](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L194)
+Defined in: [packages/core/src/types.ts:194](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L194)
 
 Element type identifier
 

--- a/docs/src/content/docs/api/interfaces/MockListElement.md
+++ b/docs/src/content/docs/api/interfaces/MockListElement.md
@@ -5,7 +5,7 @@ prev: false
 title: "MockListElement"
 ---
 
-Defined in: [packages/core/src/types.ts:220](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L220)
+Defined in: [packages/core/src/types.ts:220](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L220)
 
 List element for displaying multiple items
 
@@ -19,7 +19,7 @@ List element for displaying multiple items
 
 > `optional` **itemCount**: `number`
 
-Defined in: [packages/core/src/types.ts:223](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L223)
+Defined in: [packages/core/src/types.ts:223](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L223)
 
 Number of items to display (default: 3)
 
@@ -29,7 +29,7 @@ Number of items to display (default: 3)
 
 > `optional` **itemNavigateTo**: `string`
 
-Defined in: [packages/core/src/types.ts:225](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L225)
+Defined in: [packages/core/src/types.ts:225](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L225)
 
 Screen ID to navigate to when an item is clicked
 
@@ -39,7 +39,7 @@ Screen ID to navigate to when an item is clicked
 
 > **label**: `string`
 
-Defined in: [packages/core/src/types.ts:165](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L165)
+Defined in: [packages/core/src/types.ts:165](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L165)
 
 Display label for the element
 
@@ -53,7 +53,7 @@ Display label for the element
 
 > **type**: `"list"`
 
-Defined in: [packages/core/src/types.ts:221](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L221)
+Defined in: [packages/core/src/types.ts:221](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L221)
 
 Element type identifier
 

--- a/docs/src/content/docs/api/interfaces/MockSection.md
+++ b/docs/src/content/docs/api/interfaces/MockSection.md
@@ -5,7 +5,7 @@ prev: false
 title: "MockSection"
 ---
 
-Defined in: [packages/core/src/types.ts:256](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L256)
+Defined in: [packages/core/src/types.ts:256](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L256)
 
 Section containing grouped mock elements
 
@@ -15,7 +15,7 @@ Section containing grouped mock elements
 
 > `optional` **children**: `MockSection`[]
 
-Defined in: [packages/core/src/types.ts:264](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L264)
+Defined in: [packages/core/src/types.ts:264](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L264)
 
 Nested child sections
 
@@ -25,7 +25,7 @@ Nested child sections
 
 > **elements**: [`MockElement`](/screenbook/api/type-aliases/mockelement/)[]
 
-Defined in: [packages/core/src/types.ts:262](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L262)
+Defined in: [packages/core/src/types.ts:262](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L262)
 
 Elements within this section
 
@@ -35,7 +35,7 @@ Elements within this section
 
 > `optional` **layout**: [`MockLayout`](/screenbook/api/type-aliases/mocklayout/)
 
-Defined in: [packages/core/src/types.ts:260](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L260)
+Defined in: [packages/core/src/types.ts:260](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L260)
 
 Layout direction (default: "vertical")
 
@@ -45,6 +45,6 @@ Layout direction (default: "vertical")
 
 > `optional` **title**: `string`
 
-Defined in: [packages/core/src/types.ts:258](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L258)
+Defined in: [packages/core/src/types.ts:258](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L258)
 
 Optional section title

--- a/docs/src/content/docs/api/interfaces/MockTableElement.md
+++ b/docs/src/content/docs/api/interfaces/MockTableElement.md
@@ -5,7 +5,7 @@ prev: false
 title: "MockTableElement"
 ---
 
-Defined in: [packages/core/src/types.ts:231](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L231)
+Defined in: [packages/core/src/types.ts:231](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L231)
 
 Table element for displaying tabular data
 
@@ -19,7 +19,7 @@ Table element for displaying tabular data
 
 > `optional` **columns**: `string`[]
 
-Defined in: [packages/core/src/types.ts:234](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L234)
+Defined in: [packages/core/src/types.ts:234](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L234)
 
 Column headers
 
@@ -29,7 +29,7 @@ Column headers
 
 > **label**: `string`
 
-Defined in: [packages/core/src/types.ts:165](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L165)
+Defined in: [packages/core/src/types.ts:165](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L165)
 
 Display label for the element
 
@@ -43,7 +43,7 @@ Display label for the element
 
 > `optional` **rowCount**: `number`
 
-Defined in: [packages/core/src/types.ts:236](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L236)
+Defined in: [packages/core/src/types.ts:236](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L236)
 
 Number of rows to display (default: 3)
 
@@ -53,7 +53,7 @@ Number of rows to display (default: 3)
 
 > `optional` **rowNavigateTo**: `string`
 
-Defined in: [packages/core/src/types.ts:238](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L238)
+Defined in: [packages/core/src/types.ts:238](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L238)
 
 Screen ID to navigate to when a row is clicked
 
@@ -63,7 +63,7 @@ Screen ID to navigate to when a row is clicked
 
 > **type**: `"table"`
 
-Defined in: [packages/core/src/types.ts:232](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L232)
+Defined in: [packages/core/src/types.ts:232](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L232)
 
 Element type identifier
 

--- a/docs/src/content/docs/api/interfaces/MockTextElement.md
+++ b/docs/src/content/docs/api/interfaces/MockTextElement.md
@@ -5,7 +5,7 @@ prev: false
 title: "MockTextElement"
 ---
 
-Defined in: [packages/core/src/types.ts:202](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L202)
+Defined in: [packages/core/src/types.ts:202](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L202)
 
 Text element for labels and headings
 
@@ -19,7 +19,7 @@ Text element for labels and headings
 
 > **label**: `string`
 
-Defined in: [packages/core/src/types.ts:165](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L165)
+Defined in: [packages/core/src/types.ts:165](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L165)
 
 Display label for the element
 
@@ -33,7 +33,7 @@ Display label for the element
 
 > **type**: `"text"`
 
-Defined in: [packages/core/src/types.ts:203](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L203)
+Defined in: [packages/core/src/types.ts:203](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L203)
 
 Element type identifier
 
@@ -47,6 +47,6 @@ Element type identifier
 
 > `optional` **variant**: `"heading"` \| `"subheading"` \| `"body"` \| `"caption"`
 
-Defined in: [packages/core/src/types.ts:205](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L205)
+Defined in: [packages/core/src/types.ts:205](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L205)
 
 Text style variant

--- a/docs/src/content/docs/api/interfaces/OpenApiConfig.md
+++ b/docs/src/content/docs/api/interfaces/OpenApiConfig.md
@@ -5,7 +5,7 @@ prev: false
 title: "OpenApiConfig"
 ---
 
-Defined in: [packages/core/src/types.ts:460](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L460)
+Defined in: [packages/core/src/types.ts:460](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L460)
 
 OpenAPI specification configuration for validating dependsOn references.
 
@@ -23,7 +23,7 @@ const openapi: OpenApiConfig = {
 
 > **sources**: `string`[]
 
-Defined in: [packages/core/src/types.ts:467](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L467)
+Defined in: [packages/core/src/types.ts:467](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L467)
 
 OpenAPI specification sources (local files or remote URLs).
 Supports OpenAPI 2.0 (Swagger) and 3.x specifications.

--- a/docs/src/content/docs/api/interfaces/Screen.md
+++ b/docs/src/content/docs/api/interfaces/Screen.md
@@ -5,7 +5,7 @@ prev: false
 title: "Screen"
 ---
 
-Defined in: [packages/core/src/types.ts:49](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L49)
+Defined in: [packages/core/src/types.ts:49](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L49)
 
 Screen metadata definition for the screen catalog.
 
@@ -29,7 +29,7 @@ const screen: Screen = {
 
 > `optional` **allowCycles**: `boolean`
 
-Defined in: [packages/core/src/types.ts:115](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L115)
+Defined in: [packages/core/src/types.ts:115](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L115)
 
 Allow circular navigation involving this screen.
 When true, cycles that include this screen will not trigger warnings.
@@ -52,7 +52,7 @@ true
 
 > `optional` **dependsOn**: `string`[]
 
-Defined in: [packages/core/src/types.ts:93](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L93)
+Defined in: [packages/core/src/types.ts:93](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L93)
 
 APIs or services this screen depends on for impact analysis
 
@@ -72,7 +72,7 @@ APIs or services this screen depends on for impact analysis
 
 > `optional` **description**: `string`
 
-Defined in: [packages/core/src/types.ts:121](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L121)
+Defined in: [packages/core/src/types.ts:121](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L121)
 
 Optional description explaining the screen's purpose
 
@@ -88,7 +88,7 @@ Optional description explaining the screen's purpose
 
 > `optional` **entryPoints**: `string`[]
 
-Defined in: [packages/core/src/types.ts:100](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L100)
+Defined in: [packages/core/src/types.ts:100](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L100)
 
 Screen IDs that can navigate to this screen (incoming edges)
 
@@ -108,7 +108,7 @@ Screen IDs that can navigate to this screen (incoming edges)
 
 > **id**: `string`
 
-Defined in: [packages/core/src/types.ts:56](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L56)
+Defined in: [packages/core/src/types.ts:56](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L56)
 
 Unique identifier for the screen using dot notation
 
@@ -132,7 +132,7 @@ Unique identifier for the screen using dot notation
 
 > `optional` **links**: [`ScreenLink`](/screenbook/api/interfaces/screenlink/)[]
 
-Defined in: [packages/core/src/types.ts:127](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L127)
+Defined in: [packages/core/src/types.ts:127](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L127)
 
 Links to external resources like Storybook, Figma, or documentation
 
@@ -148,7 +148,7 @@ Links to external resources like Storybook, Figma, or documentation
 
 > `optional` **mock**: [`ScreenMock`](/screenbook/api/interfaces/screenmock/)
 
-Defined in: [packages/core/src/types.ts:134](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L134)
+Defined in: [packages/core/src/types.ts:134](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L134)
 
 Wireframe-level mock definition for UI documentation.
 When defined, navigation targets (navigateTo, itemNavigateTo, rowNavigateTo)
@@ -160,7 +160,7 @@ are automatically extracted and merged into the `next` array.
 
 > `optional` **next**: `string`[]
 
-Defined in: [packages/core/src/types.ts:107](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L107)
+Defined in: [packages/core/src/types.ts:107](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L107)
 
 Screen IDs this screen can navigate to (outgoing edges)
 
@@ -180,7 +180,7 @@ Screen IDs this screen can navigate to (outgoing edges)
 
 > `optional` **owner**: `string`[]
 
-Defined in: [packages/core/src/types.ts:79](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L79)
+Defined in: [packages/core/src/types.ts:79](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L79)
 
 Team(s) or domain(s) that own this screen
 
@@ -200,7 +200,7 @@ Team(s) or domain(s) that own this screen
 
 > **route**: `string`
 
-Defined in: [packages/core/src/types.ts:72](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L72)
+Defined in: [packages/core/src/types.ts:72](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L72)
 
 Route path pattern with optional dynamic segments
 
@@ -224,7 +224,7 @@ Route path pattern with optional dynamic segments
 
 > `optional` **tags**: `string`[]
 
-Defined in: [packages/core/src/types.ts:86](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L86)
+Defined in: [packages/core/src/types.ts:86](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L86)
 
 Tags for categorization and filtering in the catalog
 
@@ -244,7 +244,7 @@ Tags for categorization and filtering in the catalog
 
 > **title**: `string`
 
-Defined in: [packages/core/src/types.ts:64](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L64)
+Defined in: [packages/core/src/types.ts:64](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L64)
 
 Human-readable title displayed in the screen catalog
 

--- a/docs/src/content/docs/api/interfaces/ScreenLink.md
+++ b/docs/src/content/docs/api/interfaces/ScreenLink.md
@@ -5,7 +5,7 @@ prev: false
 title: "ScreenLink"
 ---
 
-Defined in: [packages/core/src/types.ts:11](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L11)
+Defined in: [packages/core/src/types.ts:11](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L11)
 
 External link to related resources
 
@@ -15,7 +15,7 @@ External link to related resources
 
 > **label**: `string`
 
-Defined in: [packages/core/src/types.ts:17](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L17)
+Defined in: [packages/core/src/types.ts:17](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L17)
 
 Display label for the link
 
@@ -35,7 +35,7 @@ Display label for the link
 
 > `optional` **type**: [`ScreenLinkType`](/screenbook/api/type-aliases/screenlinktype/)
 
-Defined in: [packages/core/src/types.ts:30](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L30)
+Defined in: [packages/core/src/types.ts:30](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L30)
 
 Type of link for icon display
 If not specified, the type is inferred from the URL
@@ -56,7 +56,7 @@ If not specified, the type is inferred from the URL
 
 > **url**: `string`
 
-Defined in: [packages/core/src/types.ts:23](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L23)
+Defined in: [packages/core/src/types.ts:23](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L23)
 
 URL to the external resource
 

--- a/docs/src/content/docs/api/interfaces/ScreenMock.md
+++ b/docs/src/content/docs/api/interfaces/ScreenMock.md
@@ -5,7 +5,7 @@ prev: false
 title: "ScreenMock"
 ---
 
-Defined in: [packages/core/src/types.ts:270](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L270)
+Defined in: [packages/core/src/types.ts:270](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L270)
 
 Complete mock definition for a screen
 
@@ -15,6 +15,6 @@ Complete mock definition for a screen
 
 > **sections**: [`MockSection`](/screenbook/api/interfaces/mocksection/)[]
 
-Defined in: [packages/core/src/types.ts:272](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L272)
+Defined in: [packages/core/src/types.ts:272](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L272)
 
 Sections containing UI elements

--- a/docs/src/content/docs/api/type-aliases/MockElement.md
+++ b/docs/src/content/docs/api/type-aliases/MockElement.md
@@ -7,6 +7,6 @@ title: "MockElement"
 
 > **MockElement** = [`MockButtonElement`](/screenbook/api/interfaces/mockbuttonelement/) \| [`MockInputElement`](/screenbook/api/interfaces/mockinputelement/) \| [`MockLinkElement`](/screenbook/api/interfaces/mocklinkelement/) \| [`MockTextElement`](/screenbook/api/interfaces/mocktextelement/) \| [`MockImageElement`](/screenbook/api/interfaces/mockimageelement/) \| [`MockListElement`](/screenbook/api/interfaces/mocklistelement/) \| [`MockTableElement`](/screenbook/api/interfaces/mocktableelement/)
 
-Defined in: [packages/core/src/types.ts:244](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L244)
+Defined in: [packages/core/src/types.ts:244](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L244)
 
 Union type of all mock element variants

--- a/docs/src/content/docs/api/type-aliases/MockElementType.md
+++ b/docs/src/content/docs/api/type-aliases/MockElementType.md
@@ -7,6 +7,6 @@ title: "MockElementType"
 
 > **MockElementType** = `"button"` \| `"input"` \| `"link"` \| `"text"` \| `"image"` \| `"list"` \| `"table"`
 
-Defined in: [packages/core/src/types.ts:149](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L149)
+Defined in: [packages/core/src/types.ts:149](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L149)
 
 Available element types for mock wireframes

--- a/docs/src/content/docs/api/type-aliases/MockLayout.md
+++ b/docs/src/content/docs/api/type-aliases/MockLayout.md
@@ -7,6 +7,6 @@ title: "MockLayout"
 
 > **MockLayout** = `"vertical"` \| `"horizontal"`
 
-Defined in: [packages/core/src/types.ts:144](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L144)
+Defined in: [packages/core/src/types.ts:144](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L144)
 
 Layout direction for mock sections

--- a/docs/src/content/docs/api/type-aliases/ScreenInput.md
+++ b/docs/src/content/docs/api/type-aliases/ScreenInput.md
@@ -7,7 +7,7 @@ title: "ScreenInput"
 
 > **ScreenInput** = [`Screen`](/screenbook/api/interfaces/screen/)
 
-Defined in: [packages/core/src/types.ts:361](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L361)
+Defined in: [packages/core/src/types.ts:361](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L361)
 
 Input type for defineScreen function.
 Same as Screen but used for input validation.

--- a/docs/src/content/docs/api/type-aliases/ScreenLinkType.md
+++ b/docs/src/content/docs/api/type-aliases/ScreenLinkType.md
@@ -7,6 +7,6 @@ title: "ScreenLinkType"
 
 > **ScreenLinkType** = `"figma"` \| `"storybook"` \| `"docs"` \| `"other"`
 
-Defined in: [packages/core/src/types.ts:6](https://github.com/wadakatu/screenbook/blob/4297cef1bf18ac5352258b2adf457cafe1df7d79/packages/core/src/types.ts#L6)
+Defined in: [packages/core/src/types.ts:6](https://github.com/wadakatu/screenbook/blob/ef23c0f12ae1a1d049097d28de425394d6bc08ee/packages/core/src/types.ts#L6)
 
 Type of external link for icon display

--- a/docs/src/content/docs/cli/index.mdx
+++ b/docs/src/content/docs/cli/index.mdx
@@ -10,9 +10,9 @@ Screenbook provides a powerful CLI to manage your screen catalog.
 ## Installation
 
 ```bash
-npm install -g @screenbook/cli
+npm install -D screenbook
 # or
-pnpm add -g @screenbook/cli
+pnpm add -D screenbook
 ```
 
 ## Commands

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -12,13 +12,13 @@ description: How to install Screenbook in your project
 
 ```bash
 # npm
-npm install @screenbook/core @screenbook/cli
+npm install -D screenbook
 
 # pnpm
-pnpm add @screenbook/core @screenbook/cli
+pnpm add -D screenbook
 
 # yarn
-yarn add @screenbook/core @screenbook/cli
+yarn add -D screenbook
 ```
 
 ## Initialize


### PR DESCRIPTION
# 概要

インストール手順を最新化し、`pnpm add -D screenbook` でのインストールを推奨するように更新。

## 変更内容

- `@screenbook/core` と `@screenbook/cli` の別々インストールから `screenbook` パッケージ単体に変更
- グローバルインストール (`-g`) からローカルdev dependency (`-D`) に変更
- CLI ドキュメント生成テンプレートの更新
- 上記変更に伴う LLM テキストの最新化

## 関連情報

- ドキュメントサイトの LLM 用テキスト (`llms-full.txt`, `llms.txt`) が自動的に最新化されます