### PR TITLE
fix(ui): include source files in npm package for dev command

### DIFF
--- a/.changeset/fix-dev-command-404.md
+++ b/.changeset/fix-dev-command-404.md
@@ -1,0 +1,7 @@
+---
+"@screenbook/ui": patch
+---
+
+fix: include source files in npm package for dev command to work
+
+The `screenbook dev` command was returning 404 on all routes because the Astro source files (`src/pages`, etc.) were not included in the published npm package. This fix adds `src`, `public`, `astro.config.mjs`, and `tsconfig.json` to the `files` field in package.json.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -39,6 +39,10 @@
 		"url": "https://github.com/wadakatu/screenbook/issues"
 	},
 	"files": [
+		"src",
+		"public",
+		"astro.config.mjs",
+		"tsconfig.json",
 		"dist",
 		"README.md"
 	],


### PR DESCRIPTION
## Summary
- Add `src`, `public`, `astro.config.mjs`, and `tsconfig.json` to the `files` field in `@screenbook/ui`'s package.json
- This ensures the Astro source files are included in the published npm package

## Root Cause
The `screenbook dev` command starts an Astro dev server using the installed `@screenbook/ui` package. However, the package.json's `files` field only included `["dist", "README.md"]`, meaning the `src/pages` directory required by Astro was not included in the published package. This caused Astro to show the "Missing pages directory: src/pages" warning and return 404 for all routes.

## Test plan
- [ ] Run `pnpm lint` - passes
- [ ] Run `pnpm typecheck` - passes  
- [ ] Run `pnpm test` - passes
- [ ] After publishing, verify `screenbook dev` works correctly in a test project

Fixes #162