### PR TITLE
feat(cli): resolve component identifiers from imports in Vue Router parser

### DIFF
--- a/.changeset/fix-vue-router-import-resolution.md
+++ b/.changeset/fix-vue-router-import-resolution.md
@@ -1,0 +1,19 @@
+---
+"@screenbook/cli": minor
+---
+
+feat(generate): resolve component identifiers from imports in Vue Router
+
+The Vue Router parser now tracks import statements and resolves component identifiers to their file paths. This enables correct `componentPath` extraction for routes that use imported components like:
+
+```ts
+import PageProjects from './pages/PageProjects/PageProjects.vue'
+
+export const routes = [
+  { path: '/projects', component: PageProjects }  // componentPath is now resolved!
+]
+```
+
+Also fixed empty path routes (`path: ""`) being incorrectly skipped. Empty paths are valid in Vue Router and represent routes that match the parent path.
+
+This fix ensures that when using `routesFile` configuration, the generated `screen.meta.ts` files have correct route values from the actual router configuration.

--- a/packages/cli/src/__tests__/vueRouterParser.test.ts
+++ b/packages/cli/src/__tests__/vueRouterParser.test.ts
@@ -201,6 +201,74 @@ export const routes = [
 			expect(result.routes[0]?.component).toContain("views/About.vue")
 		})
 
+		it("should resolve component identifier from imports", () => {
+			const routesFile = join(testDir, "routes.ts")
+			writeFileSync(
+				routesFile,
+				`
+import PageProjects from './pages/PageProjects/PageProjects.vue'
+import { PageSettings } from './pages/PageSettings/PageSettings.vue'
+
+export const routes = [
+  {
+    path: '/projects',
+    name: 'PageProjects',
+    component: PageProjects,
+  },
+  {
+    path: '/settings',
+    name: 'PageSettings',
+    component: PageSettings,
+  },
+]
+`,
+			)
+
+			const result = parseVueRouterConfig(routesFile)
+
+			expect(result.routes).toHaveLength(2)
+			expect(result.routes[0]?.component).toContain(
+				"pages/PageProjects/PageProjects.vue",
+			)
+			expect(result.routes[1]?.component).toContain(
+				"pages/PageSettings/PageSettings.vue",
+			)
+		})
+
+		it("should resolve component identifiers in nested routes", () => {
+			const routesFile = join(testDir, "routes.ts")
+			writeFileSync(
+				routesFile,
+				`
+import LayoutEditor from './layouts/LayoutEditor.vue'
+import PageProjects from './pages/PageProjects/PageProjects.vue'
+
+export const routes = [
+  {
+    path: '/projects',
+    component: LayoutEditor,
+    children: [
+      {
+        path: '',
+        name: 'PageProjects',
+        component: PageProjects,
+      },
+    ],
+  },
+]
+`,
+			)
+
+			const result = parseVueRouterConfig(routesFile)
+
+			expect(result.routes).toHaveLength(1)
+			expect(result.routes[0]?.component).toContain("layouts/LayoutEditor.vue")
+			expect(result.routes[0]?.children).toHaveLength(1)
+			expect(result.routes[0]?.children?.[0]?.component).toContain(
+				"pages/PageProjects/PageProjects.vue",
+			)
+		})
+
 		it("should throw error when file does not exist", () => {
 			const nonExistentFile = join(testDir, "non-existent.ts")
 


### PR DESCRIPTION
## Summary
- Track import statements in Vue Router parser and resolve component identifiers to their file paths
- Fix empty path routes (`path: ""`) being incorrectly skipped - these are valid in Vue Router
- Add tests for import resolution functionality

## Root Cause
The Vue Router parser was returning `undefined` for `component: PageProjects` style component references because it wasn't tracking import statements. This meant `componentPath` was not set for these routes, leading to incorrect `screen.meta.ts` generation.

Also, routes with `path: ""` (which match the parent path in Vue Router) were being skipped because `!route.path` was truthy for empty strings.

## Changes
- Added `buildImportMap` function to track `import` statements
- Updated `extractComponentPath` to look up identifiers in the import map
- Fixed empty path handling by using a `hasPath` flag instead of truthy check
- Added test cases for import resolution

## Example
Before (broken):
```ts
import PageProjects from './pages/PageProjects.vue'
export const routes = [
  { path: '/projects', component: PageProjects }
]
// componentPath: undefined ❌
```

After (fixed):
```ts
// componentPath: "pages/PageProjects.vue" ✅
```

## Test plan
- [x] `pnpm lint` - passes
- [x] `pnpm typecheck` - passes
- [x] `pnpm test` - all 687 tests pass
- [x] New tests added for import resolution

Fixes #163