### PR TITLE
fix(ui): escape slashes in Mermaid graph labels

### DIFF
--- a/examples/vue-router/src/router/routes.ts
+++ b/examples/vue-router/src/router/routes.ts
@@ -35,4 +35,10 @@ export const routes: RouteRecordRaw[] = [
 		name: "projects",
 		component: () => import("../views/PageProjects/index.vue"),
 	},
+	// Issue #171: Title containing slash to test Mermaid graph escaping
+	{
+		path: "/admin/dashboard",
+		name: "admin-dashboard",
+		component: () => import("../views/AdminDashboard/index.vue"),
+	},
 ]

--- a/examples/vue-router/src/views/AdminDashboard/index.vue
+++ b/examples/vue-router/src/views/AdminDashboard/index.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+// Admin Dashboard - test case for issue #171 (slash in title)
+</script>
+
+<template>
+	<div class="admin-dashboard">
+		<h1>Admin / Dashboard</h1>
+		<p>This page tests Mermaid graph rendering with slashes in screen titles.</p>
+	</div>
+</template>
+
+<style scoped>
+.admin-dashboard {
+	padding: 2rem;
+}
+</style>

--- a/examples/vue-router/src/views/AdminDashboard/screen.meta.ts
+++ b/examples/vue-router/src/views/AdminDashboard/screen.meta.ts
@@ -1,0 +1,19 @@
+import { defineScreen } from "@screenbook/core"
+
+export const screen = defineScreen({
+	id: "admin.dashboard",
+	// Title containing slash to test Mermaid escaping (issue #171)
+	title: "Admin / Dashboard",
+	route: "/admin/dashboard",
+
+	owner: ["admin"],
+
+	tags: ["admin", "dashboard"],
+
+	// API dependencies to also test the API graph
+	dependsOn: ["AdminAPI.getStats", "UserAPI/v2.getUsers"],
+
+	entryPoints: ["home"],
+
+	next: ["settings"],
+})

--- a/packages/ui/src/pages/graph.astro
+++ b/packages/ui/src/pages/graph.astro
@@ -4,6 +4,13 @@ import { loadScreens } from "@/utils/loadScreens"
 
 const screens = loadScreens()
 
+// Escape special characters for Mermaid labels
+function escapeMermaidLabel(text: string): string {
+	return text
+		.replace(/"/g, "'")
+		.replace(/\//g, "&#47;")
+}
+
 // Generate Navigation Mermaid graph
 let navigationGraph = ""
 const screensWithMock: string[] = []
@@ -11,7 +18,7 @@ if (screens.length > 0) {
 	const lines: string[] = ["flowchart TD"]
 
 	for (const screen of screens) {
-		const label = screen.title.replace(/"/g, "'")
+		const label = escapeMermaidLabel(screen.title)
 		const id = screen.id.replace(/\./g, "_")
 		const mockIndicator = screen.mock ? " 📱" : ""
 		lines.push(`    ${id}["${label}${mockIndicator}"]`)
@@ -70,7 +77,8 @@ if (screens.length > 0) {
 	lines.push("    %% API nodes")
 	for (const api of apis) {
 		const id = api.replace(/\./g, "_")
-		lines.push(`    ${id}[/"${api}"/]`)
+		const label = escapeMermaidLabel(api)
+		lines.push(`    ${id}[/"${label}"/]`)
 	}
 
 	lines.push("")
@@ -79,7 +87,7 @@ if (screens.length > 0) {
 	// Add screen nodes
 	for (const screen of screens) {
 		if (screen.dependsOn && screen.dependsOn.length > 0) {
-			const label = screen.title.replace(/"/g, "'")
+			const label = escapeMermaidLabel(screen.title)
 			const id = screen.id.replace(/\./g, "_")
 			lines.push(`    ${id}["${label}"]`)
 		}


### PR DESCRIPTION
## Summary
- Add `escapeMermaidLabel` helper function to escape special characters (`/` and `"`) in Mermaid node labels
- Apply escaping to Navigation graph screen titles and API Dependencies graph labels
- Add test case in vue-router example with "Admin / Dashboard" title

## Test plan
- [x] Verified Navigation graph renders correctly with slash in title ("Admin / Dashboard")
- [x] Verified API Dependencies graph renders correctly with slash in API name ("UserAPI/v2")
- [x] All existing tests pass
- [x] Build succeeds

Fixes #171