### PR TITLE
Bugfix: Inconsistent coverage calculation between lint and build commands

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -215,8 +215,11 @@ async function generateCoverageData(
 	}
 
 	// Calculate coverage
+	// When routesPattern is configured, count route files (not screens)
+	// This ensures consistency with the lint command
 	const total = routeFiles.length > 0 ? routeFiles.length : screens.length
-	const covered = screens.length
+	const covered =
+		routeFiles.length > 0 ? routeFiles.length - missing.length : screens.length
 	const percentage = total > 0 ? Math.round((covered / total) * 100) : 100
 
 	// Group by owner


### PR DESCRIPTION
# 概要

`screenbook lint`と`screenbook build`コマンドでカバレッジ計算が一致していない問題を修正しました。

## 変更内容

`build`コマンドの`generateCoverageData`関数でカバレッジ計算ロジックを修正しました。

- `covered`を`screens.length`（screen.meta.tsの数）ではなく、`routeFiles.length - missing.length`（screen.meta.tsがあるディレクトリのroute files数）として計算するように変更
- 複数のrouteファイルが同じscreen.meta.tsを共有するケースを再現するテストケースを追加

### 修正前の動作
```
build: Coverage: 52/150 (35%)  # screens.length / routeFiles.length
lint:  Coverage: 150/150 (100%)
```

### 修正後の動作
```
build: Coverage: 9/12 (75%)  # 一致
lint:  Coverage: 9/12 (75%)  # 一致
```

## 関連情報

- Closes #174