### PR TITLE
fix(ui): expand graph visualization to use available space

### DIFF
--- a/packages/ui/src/styles/global.css
+++ b/packages/ui/src/styles/global.css
@@ -612,9 +612,6 @@ code {
 	border-radius: var(--radius-lg);
 	padding: 32px;
 	min-height: 400px;
-	display: flex;
-	justify-content: center;
-	align-items: center;
 }
 
 .graph-legend {
@@ -824,6 +821,12 @@ code {
 /* Mermaid */
 .mermaid {
 	background: transparent;
+	width: 100%;
+}
+
+.mermaid svg {
+	width: 100%;
+	height: auto;
 }
 
 .mermaid .node rect {


### PR DESCRIPTION
## Summary

- Fix graph visualization being too small and not utilizing available container space
- Remove flex centering from `.graph-container` that was constraining the SVG size
- Add `width: 100%` to Mermaid elements to allow graphs to expand

## Before / After

**Before**: Graphs rendered as small clusters in the center of the container  
**After**: Graphs expand to fill the available width, making node labels easier to read

## Test plan

- [x] Verify Navigation graph on `/graph` page expands properly
- [x] Verify API Dependencies graph expands properly
- [x] Verify Impact Analysis graph on `/impact` page expands properly
- [x] Run lint and typecheck

Closes #177