### PR TITLE
chore: add changeset for v1.8.0 release

### DIFF
--- a/.changeset/fix-cli-ui-bugs.md
+++ b/.changeset/fix-cli-ui-bugs.md
@@ -1,0 +1,17 @@
+---
+"@screenbook/cli": patch
+"@screenbook/ui": patch
+"screenbook": patch
+---
+
+### @screenbook/cli
+
+- Fix coverage calculation to use route files count instead of total routes
+- Fix missing routes identification in coverage.json
+- Exclude component directories from screen.meta.ts generation
+- Use Vue Router config for route extraction in routesPattern mode
+
+### @screenbook/ui
+
+- Expand graph visualization to use available container space
+- Escape slashes in Mermaid graph labels


### PR DESCRIPTION
## Summary

Add changeset for the upcoming v1.8.0 patch release including all bug fixes since v1.7.0.

## Changes included

### @screenbook/cli
- Fix coverage calculation to use route files count (#179)
- Fix missing routes identification in coverage.json (#178)
- Exclude component directories from screen.meta.ts generation (#175)
- Use Vue Router config for route extraction in routesPattern mode (#173)

### @screenbook/ui
- Expand graph visualization to use available container space (#180)
- Escape slashes in Mermaid graph labels (#176)

## Release Flow

1. ✅ Add changeset (this PR)
2. ⏳ Merge this PR
3. ⏳ GitHub Action creates "Version Packages" PR automatically
4. ⏳ Merge "Version Packages" PR
5. ⏳ GitHub Action publishes to npm