### PR TITLE
fix(generate): handle Vue Router catch-all patterns correctly

### DIFF
--- a/examples/vue-router/src/router/routes.ts
+++ b/examples/vue-router/src/router/routes.ts
@@ -49,4 +49,11 @@ export const routes: RouteRecordRaw[] = [
 		name: "admin",
 		component: () => import("../views/PageAdmin/components/AdminLayout.vue"),
 	},
+	// Issue #202: Catch-all route for 404 pages
+	// Tests that :pathMatch(.*)* generates valid ID and tags
+	{
+		path: "/:pathMatch(.*)*",
+		name: "PageNotFound",
+		component: () => import("../views/PageNotFound/index.vue"),
+	},
 ]

--- a/examples/vue-router/src/views/PageNotFound/index.vue
+++ b/examples/vue-router/src/views/PageNotFound/index.vue
@@ -1,0 +1,18 @@
+<template>
+	<div class="not-found">
+		<h1>404 - Page Not Found</h1>
+		<p>The page you are looking for does not exist.</p>
+		<router-link to="/">Go Home</router-link>
+	</div>
+</template>
+
+<script setup lang="ts">
+// Issue #202: Test component for catch-all route
+</script>
+
+<style scoped>
+.not-found {
+	text-align: center;
+	padding: 2rem;
+}
+</style>

--- a/examples/vue-router/src/views/PageNotFound/screen.meta.ts
+++ b/examples/vue-router/src/views/PageNotFound/screen.meta.ts
@@ -1,0 +1,23 @@
+import { defineScreen } from "screenbook"
+
+export const screen = defineScreen({
+	id: "not-found",
+	title: "Not Found",
+	route: "/:pathMatch(.*)*",
+
+	// Team or individual responsible for this screen
+	owner: [],
+
+	// Tags for filtering in the catalog
+	tags: ["not-found"],
+
+	// APIs/services this screen depends on (for impact analysis)
+	// Example: ["UserAPI.getProfile", "PaymentService.checkout"]
+	dependsOn: [],
+
+	// Screen IDs that can navigate to this screen
+	entryPoints: [],
+
+	// Screen IDs this screen can navigate to
+	next: [],
+})

--- a/packages/cli/src/__tests__/routeParserUtils.test.ts
+++ b/packages/cli/src/__tests__/routeParserUtils.test.ts
@@ -3,6 +3,7 @@ import {
 	flattenRoutes,
 	type ParsedRoute,
 	pathToScreenId,
+	pathToScreenTitle,
 } from "../utils/routeParserUtils.js"
 
 describe("routeParserUtils", () => {
@@ -259,6 +260,67 @@ describe("routeParserUtils", () => {
 
 			expect(flat).toHaveLength(1)
 			expect(flat[0]?.screenId).toBe("posts.article")
+		})
+	})
+
+	describe("pathToScreenId - Vue Router catch-all patterns", () => {
+		it("should convert :pathMatch(.*)* to not-found", () => {
+			expect(pathToScreenId("/:pathMatch(.*)*")).toEqual({
+				screenId: "not-found",
+			})
+		})
+
+		it("should convert :catchAll(.*)* to not-found", () => {
+			expect(pathToScreenId("/:catchAll(.*)*")).toEqual({
+				screenId: "not-found",
+			})
+		})
+
+		it("should convert :pathMatch(.*) without trailing asterisk to not-found", () => {
+			expect(pathToScreenId("/:pathMatch(.*)")).toEqual({
+				screenId: "not-found",
+			})
+		})
+
+		it("should handle catch-all with prefix path", () => {
+			expect(pathToScreenId("/admin/:pathMatch(.*)*")).toEqual({
+				screenId: "admin.not-found",
+			})
+		})
+
+		it("should handle catch-all with nested path", () => {
+			expect(pathToScreenId("/docs/guide/:pathMatch(.*)*")).toEqual({
+				screenId: "docs.guide.not-found",
+			})
+		})
+
+		it("should not affect regular parameters with parentheses in name", () => {
+			// Regular parameters should still work
+			expect(pathToScreenId("/users/:id")).toEqual({
+				screenId: "users.id",
+			})
+		})
+	})
+
+	describe("pathToScreenTitle - Vue Router catch-all patterns", () => {
+		it("should return 'Not Found' for :pathMatch(.*)* pattern", () => {
+			expect(pathToScreenTitle("/:pathMatch(.*)*")).toBe("Not Found")
+		})
+
+		it("should return 'Not Found' for :catchAll(.*)* pattern", () => {
+			expect(pathToScreenTitle("/:catchAll(.*)*")).toBe("Not Found")
+		})
+
+		it("should return 'Not Found' for catch-all with prefix path", () => {
+			expect(pathToScreenTitle("/admin/:pathMatch(.*)*")).toBe("Not Found")
+		})
+
+		it("should return normal title for regular paths", () => {
+			expect(pathToScreenTitle("/users/profile")).toBe("Profile")
+		})
+
+		it("should return Home for root path", () => {
+			expect(pathToScreenTitle("/")).toBe("Home")
 		})
 	})
 })


### PR DESCRIPTION
## Summary
- Fix issue where Vue Router catch-all routes (e.g., `/:pathMatch(.*)*`) generated invalid screen IDs and tags
- Add `isVueCatchallPattern` helper function to detect catch-all patterns
- Update `pathToScreenId` to convert catch-all patterns to `not-found`
- Update `pathToScreenTitle` to return `Not Found` for catch-all routes

## Before / After

| Field | Before | After |
|-------|--------|-------|
| ID | `pathMatch(.*)*` | `not-found` |
| Title | `Home` | `Not Found` |
| Tags | `["pathMatch("]` | `["not-found"]` |

## Test plan
- [x] Added unit tests for `pathToScreenId` with Vue Router catch-all patterns
- [x] Added unit tests for `pathToScreenTitle` with catch-all patterns
- [x] Verified with vue-router example (PageNotFound component)
- [x] All 810 tests pass
- [x] Lint and typecheck pass

Closes #202