### PR TITLE
Bugfix: Apply excludePatterns in build coverage calculation

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -6,6 +6,10 @@ import { createJiti } from "jiti"
 import { glob } from "tinyglobby"
 import { loadConfig } from "../utils/config.js"
 import {
+	DEFAULT_EXCLUDE_PATTERNS,
+	matchesExcludePattern,
+} from "../utils/constants.js"
+import {
 	detectCycles,
 	formatCycleWarnings,
 	getCycleSummary,
@@ -173,7 +177,12 @@ export const buildCommand = define({
 })
 
 async function generateCoverageData(
-	config: { routesPattern?: string; metaPattern: string; ignore: string[] },
+	config: {
+		routesPattern?: string
+		metaPattern: string
+		ignore: string[]
+		excludePatterns?: string[]
+	},
 	cwd: string,
 	screens: Array<Screen & { filePath?: string }>,
 ): Promise<CoverageData> {
@@ -184,6 +193,13 @@ async function generateCoverageData(
 			cwd,
 			ignore: config.ignore,
 		})
+
+		// Apply exclude patterns (consistent with lint command)
+		// This filters out component directories like "components/", "hooks/", etc.
+		const excludePatterns = config.excludePatterns ?? DEFAULT_EXCLUDE_PATTERNS
+		routeFiles = routeFiles.filter(
+			(file) => !matchesExcludePattern(file, excludePatterns),
+		)
 	}
 
 	// Build a set of directories that have screen.meta.ts


### PR DESCRIPTION
# 概要

build コマンドのカバレッジ計算で excludePatterns が適用されていなかったバグを修正

## 変更内容

`routesPattern` を使用した場合、`components/` などのサブディレクトリ内のファイルがルートとしてカウントされ、カバレッジが誤って低く計算される問題を修正しました。

- `generateCoverageData()` 関数に `excludePatterns` フィルタリングを追加
- `lint` コマンドと同じロジックを適用し、`DEFAULT_EXCLUDE_PATTERNS`（`**/components/**`, `**/shared/**` など）でフィルタリング
- Issue #203 のシナリオを再現するテストを追加
- カスタム `excludePatterns` の動作確認テストを追加

## 関連情報

- Closes #203